### PR TITLE
Fix windows support package cask for unity > 2018

### DIFF
--- a/install/uvm-install/src/main.rs
+++ b/install/uvm-install/src/main.rs
@@ -13,6 +13,7 @@ use uvm_cli::ColorOption;
 use std::collections::HashSet;
 use uvm_core::unity::Version;
 use uvm_install_core::InstallVariant;
+use std::str::FromStr;
 
 use console::style;
 use std::process;
@@ -79,7 +80,12 @@ impl InstallOptions {
                 variants.insert(InstallVariant::WebGl);
             }
 
-            if self.flag_windows || self.flag_desktop || self.flag_all {
+            let check_version = Version::from_str("2018.0.0b0").unwrap();
+            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() >= &check_version {
+                variants.insert(InstallVariant::WindowsMono);
+            }
+
+            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() < &check_version {
                 variants.insert(InstallVariant::Windows);
             }
 
@@ -144,7 +150,7 @@ fn install(options: InstallOptions) -> io::Result<()> {
             write!(stderr, "{}\n", style(c).cyan()).ok();
         }
 
-        let mut diff = to_install.union(&installed).peekable();
+        let mut diff = to_install.intersection(&installed).peekable();
         if let Some(_) = diff.peek() {
             stderr.write_line("").ok();
             write!(stderr, "{}\n", style("Skip variants already installed:").yellow()).ok();

--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -17,6 +17,7 @@ pub enum InstallVariant {
     WebGl,
     Linux,
     Windows,
+    WindowsMono,
     Editor,
 }
 
@@ -28,6 +29,7 @@ impl fmt::Display for InstallVariant {
             &InstallVariant::WebGl => write!(f, "webgl"),
             &InstallVariant::Linux => write!(f, "linux"),
             &InstallVariant::Windows => write!(f, "windows"),
+            &InstallVariant::WindowsMono => write!(f, "windows-mono"),
             _ => write!(f, "editor"),
         }
     }


### PR DESCRIPTION
Unity changed the component name of the windows support component from
`windows` to `windows-mono` for all versions > 2018