### PR TITLE
Add UvmError a error wrapper to replace usage of io::Result

### DIFF
--- a/commands/uvm-clear/src/lib.rs
+++ b/commands/uvm-clear/src/lib.rs
@@ -11,6 +11,7 @@ use std::io;
 use std::path::Path;
 use uvm_cli::ColorOption;
 use uvm_cli::Options;
+use uvm_core::error::UvmError;
 
 #[derive(Debug, Deserialize)]
 pub struct ClearOptions {
@@ -43,11 +44,11 @@ impl UvmCommand {
         }
     }
 
-    pub fn exec(&self, options:ClearOptions) -> io::Result<()>
+    pub fn exec(&self, options:ClearOptions) -> uvm_core::Result<()>
     {
         let active_path = Path::new(UNITY_CURRENT_LOCATION);
         if !active_path.exists() {
-            return Err(io::Error::new(io::ErrorKind::NotFound, "No active unity version"));
+            return Err(UvmError::IoError(io::Error::new(io::ErrorKind::NotFound, "No active unity version")));
         }
 
         if options.verbose() {
@@ -60,7 +61,7 @@ impl UvmCommand {
         }
 
         fs::remove_file(active_path)
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "Failed to clear active version"))?;
+            .map_err(|_| UvmError::IoError(io::Error::new(io::ErrorKind::Other, "Failed to clear active version")))?;
         self.stdout.write_line(&format!("{}", style("success").green()))?;
         Ok(())
     }

--- a/commands/uvm-launch/src/main.rs
+++ b/commands/uvm-launch/src/main.rs
@@ -9,6 +9,7 @@ use std::path::{Path};
 use std::process;
 use uvm_cli::LaunchOptions;
 use uvm_cli::Options;
+use uvm_core::Result;
 
 const USAGE: &'static str = "
 uvm-launch - Launch the current active version of unity.
@@ -32,7 +33,7 @@ Options:
 fn get_installation(
     project_path: &Path,
     use_project_version: bool,
-) -> io::Result<uvm_core::Installation> {
+) -> Result<uvm_core::Installation> {
     if use_project_version {
         let version = uvm_core::dectect_project_version(&project_path, None)?;
         return uvm_core::find_installation(&version);
@@ -41,7 +42,7 @@ fn get_installation(
     uvm_core::current_installation()
 }
 
-fn launch(options: LaunchOptions) -> io::Result<()> {
+fn launch(options: LaunchOptions) -> Result<()> {
     let project_path = uvm_core::detect_unity_project_dir(
         options.project_path().unwrap_or(&env::current_dir().unwrap()),
         options.recursive(),

--- a/uvm_core/proptest-regressions/unity/installation.txt
+++ b/uvm_core/proptest-regressions/unity/installation.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 3124185330 1871089580 2514238918 2825078417 # shrinks to ref s = "0.0.0b0"

--- a/uvm_core/proptest-regressions/unity/mod.txt
+++ b/uvm_core/proptest-regressions/unity/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 2909194352 4024440816 2114519843 86609349 # shrinks to ref s = "0.0.0p0"

--- a/uvm_core/src/error.rs
+++ b/uvm_core/src/error.rs
@@ -1,0 +1,47 @@
+use std::error::Error;
+use std::io;
+use std::fmt;
+use unity;
+
+#[derive(Debug)]
+pub enum UvmError {
+    ParseVersionError(unity::ParseVersionError),
+    IoError(io::Error),
+}
+
+impl From<io::Error> for UvmError {
+    fn from(err: io::Error) -> UvmError {
+        UvmError::IoError(err)
+    }
+}
+
+impl From<unity::ParseVersionError> for UvmError {
+    fn from(err: unity::ParseVersionError) -> UvmError {
+        UvmError::ParseVersionError(err)
+    }
+}
+
+impl Error for UvmError {
+    fn description(&self) -> &str {
+        match *self {
+            UvmError::ParseVersionError(ref err) => err.description(),
+            UvmError::IoError(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        Some(match *self {
+            UvmError::ParseVersionError(ref err) => err as &Error,
+            UvmError::IoError(ref err) => err as &Error,
+        })
+    }
+}
+
+impl fmt::Display for UvmError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UvmError::ParseVersionError(ref err) => fmt::Display::fmt(err, f),
+            UvmError::IoError(ref err) => fmt::Display::fmt(err, f),
+        }
+    }
+}

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -24,14 +24,17 @@ macro_rules! cargo_version {
 
 pub mod unity;
 pub mod brew;
+pub mod error;
+pub mod result;
 
 pub use self::unity::list_installations;
 pub use self::unity::current_installation;
-
+pub use self::result::Result;
 pub use self::unity::Installation;
 pub use self::unity::CurrentInstallation;
 pub use self::unity::Version;
 
+use self::error::UvmError;
 use std::io;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -41,6 +44,7 @@ use std::os::unix;
 use std::str::FromStr;
 use std::convert::AsRef;
 
+
 pub fn is_active(version: &Version) -> bool {
     if let Ok(current) = current_installation() {
         current.version() == version
@@ -49,17 +53,17 @@ pub fn is_active(version: &Version) -> bool {
     }
 }
 
-pub fn find_installation(version: &Version) -> io::Result<Installation> {
+pub fn find_installation(version: &Version) -> Result<Installation> {
     let mut installations = list_installations()?;
     installations
         .find(|i| i.version() == version)
         .ok_or(io::Error::new(
             io::ErrorKind::NotFound,
             format!("Unable to find Unity version {}", version),
-        ))
+        ).into())
 }
 
-pub fn activate(ref installation: Installation) -> io::Result<()> {
+pub fn activate(ref installation: Installation) -> Result<()> {
     let active_path = Path::new("/Applications/Unity");
     if active_path.exists() {
         fs::remove_file(active_path)?;

--- a/uvm_core/src/result.rs
+++ b/uvm_core/src/result.rs
@@ -1,0 +1,4 @@
+use std::result;
+use error::UvmError;
+
+pub type Result<T> = result::Result<T, UvmError>;

--- a/uvm_core/src/unity/current_installation.rs
+++ b/uvm_core/src/unity/current_installation.rs
@@ -2,18 +2,19 @@ use unity::Installation;
 use std::path::PathBuf;
 use std::path::Path;
 use std::io;
+use result::Result;
 
 pub type CurrentInstallation = Installation;
 const UNITY_CURRENT_LOCATION: &'static str = "/Applications/Unity";
 
 impl CurrentInstallation {
-    fn current(path: PathBuf) -> io::Result<Installation> {
+    fn current(path: PathBuf) -> Result<Installation> {
         let linked_file = path.read_link()?;
         CurrentInstallation::new(linked_file)
     }
 }
 
-pub fn current_installation() -> io::Result<CurrentInstallation> {
+pub fn current_installation() -> Result<CurrentInstallation> {
     let active_path = Path::new(UNITY_CURRENT_LOCATION);
     CurrentInstallation::current(active_path.to_path_buf())
 }

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -4,6 +4,7 @@ mod current_installation;
 
 pub use self::installation::Installation;
 pub use self::version::Version;
+pub use self::version::ParseVersionError;
 pub use self::version::VersionType;
 pub use self::version::unity_version_format;
 pub use self::current_installation::CurrentInstallation;
@@ -13,6 +14,7 @@ use std::fs;
 use std::path::Path;
 use std::io;
 use std::convert::From;
+use result::Result;
 
 const UNITY_INSTALL_LOCATION: &'static str = "/Applications";
 
@@ -20,14 +22,14 @@ pub struct Installations(Box<Iterator<Item = Installation>>);
 pub struct Versions(Box<Iterator<Item = Version>>);
 
 impl Installations {
-    fn new(install_location: &Path) -> io::Result<Installations> {
+    fn new(install_location: &Path) -> Result<Installations> {
         let read_dir = fs::read_dir(install_location)?;
         let iter = read_dir
-            .filter_map(io::Result::ok)
+            .filter_map(|dir_entry| dir_entry.ok())
             .filter_map(check_dir_entry)
             .map(|entry| entry.path())
             .map(Installation::new)
-            .filter_map(io::Result::ok);
+            .filter_map(Result::ok);
         Ok(Installations(Box::new(iter)))
     }
 
@@ -67,7 +69,7 @@ fn check_dir_entry(entry:fs::DirEntry) -> Option<fs::DirEntry> {
     None
 }
 
-pub fn list_installations() -> io::Result<Installations> {
+pub fn list_installations() -> Result<Installations> {
     let install_location = Path::new(UNITY_INSTALL_LOCATION);
     Installations::new(install_location)
 }


### PR DESCRIPTION
This patch introduces a custom Error Enum `UvmError` together with a
`result::Result` type defined in `uvm_core` to wrap `io::Error` and
`ParseVersionError`.