### PR TITLE
Refactor unity installation recognision logic

### DIFF
--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -7,8 +7,10 @@ authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 regex = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
+log = "0.4.5"
+plist = "0.3.0"
 
 [dev-dependencies]
 proptest = "0.8.7"
 rand = "0.5"
-tempdir = "0.3"
+tempfile = "3"

--- a/uvm_core/src/error.rs
+++ b/uvm_core/src/error.rs
@@ -2,9 +2,11 @@ use std::error::Error;
 use std::io;
 use std::fmt;
 use unity;
+use plist;
 
 #[derive(Debug)]
 pub enum UvmError {
+    PlistError(plist::Error),
     ParseVersionError(unity::ParseVersionError),
     IoError(io::Error),
 }
@@ -12,6 +14,12 @@ pub enum UvmError {
 impl From<io::Error> for UvmError {
     fn from(err: io::Error) -> UvmError {
         UvmError::IoError(err)
+    }
+}
+
+impl From<plist::Error> for UvmError {
+    fn from(err: plist::Error) -> UvmError {
+        UvmError::PlistError(err)
     }
 }
 
@@ -24,6 +32,7 @@ impl From<unity::ParseVersionError> for UvmError {
 impl Error for UvmError {
     fn description(&self) -> &str {
         match *self {
+            UvmError::PlistError(ref err) => err.description(),
             UvmError::ParseVersionError(ref err) => err.description(),
             UvmError::IoError(ref err) => err.description(),
         }
@@ -31,6 +40,7 @@ impl Error for UvmError {
 
     fn cause(&self) -> Option<&Error> {
         Some(match *self {
+            UvmError::PlistError(ref err) => err as &Error,
             UvmError::ParseVersionError(ref err) => err as &Error,
             UvmError::IoError(ref err) => err as &Error,
         })
@@ -40,6 +50,7 @@ impl Error for UvmError {
 impl fmt::Display for UvmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            UvmError::PlistError(ref err) => fmt::Display::fmt(err, f),
             UvmError::ParseVersionError(ref err) => fmt::Display::fmt(err, f),
             UvmError::IoError(ref err) => fmt::Display::fmt(err, f),
         }

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -7,7 +7,10 @@ extern crate proptest;
 #[cfg(test)]
 extern crate rand;
 #[cfg(test)]
-extern crate tempdir;
+extern crate tempfile;
+extern crate plist;
+#[macro_use]
+extern crate serde_derive;
 
 #[macro_export]
 macro_rules! cargo_version {

--- a/uvm_core/src/unity/current_installation.rs
+++ b/uvm_core/src/unity/current_installation.rs
@@ -23,21 +23,43 @@ pub fn current_installation() -> Result<CurrentInstallation> {
 mod tests {
     use std::env;
     use std::fs;
+    use std::str::FromStr;
     use std::path::Path;
     use std::path::PathBuf;
     use rand;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
+    use tempfile::Builder;
     use super::*;
     use std::os::unix;
+    use std::fs::File;
+    use unity::installation::AppInfo;
+    use plist::serde::{deserialize, serialize_to_xml};
+
+    fn create_test_path(base_dir:&PathBuf, version: &str) -> PathBuf {
+        let path = base_dir.join(format!("Unity-{version}", version = version));
+        let mut dir_builder = fs::DirBuilder::new();
+        dir_builder.recursive(true);
+        dir_builder.create(&path).unwrap();
+
+        let info_plist_path = path.join(Path::new("Unity.app/Contents/Info.plist"));
+        dir_builder.create(info_plist_path.parent().unwrap()).unwrap();
+
+        let info = AppInfo {
+            c_f_bundle_version: String::from_str(version).unwrap(),
+            unity_build_number: String::from_str("ssdsdsdd").unwrap()
+        };
+        let file = File::create(info_plist_path).unwrap();
+        serialize_to_xml(file, &info).unwrap();
+
+        path
+    }
 
     macro_rules! prepare_unity_installations {
         ($($input:expr),*) => {
             {
-                let test_dir = TempDir::new("list_installations_in_directory").unwrap();
-                let mut dir_builder = fs::DirBuilder::new();
+                let test_dir = Builder::new().prefix("current_installations").tempdir().unwrap();
                 $(
-                    let dir = test_dir.path().join($input);
-                    dir_builder.create(dir).unwrap();
+                    create_test_path(&test_dir.path().to_path_buf(), $input);
                 )*
                 test_dir
             }
@@ -55,15 +77,15 @@ mod tests {
     #[test]
     fn current_installation_returns_active_installation() {
         let test_dir = prepare_unity_installations![
-            "Unity-5.6.0p3",
-            "Unity-2017.1.0p1",
-            "Unity-2017.2.0f2"
+            "5.6.0p3",
+            "2017.1.0p1",
+            "2017.2.0f2"
         ];
 
         let dir = test_dir.path().join("Unity");
         let src = test_dir.path().join("Unity-2017.1.0p1");
-        unix::fs::symlink(&src, &dir);
-
+        unix::fs::symlink(&src, &dir).unwrap();
+        dir.read_link().unwrap();
         let subject = CurrentInstallation::current(dir).unwrap();
         assert_eq!(subject.path(), &src);
     }


### PR DESCRIPTION
Read macOS type of unity installation. This first strategy will only work on mac os machines.