### PR TITLE
Add new install to location feature

### DIFF
--- a/install/uvm-install/Cargo.toml
+++ b/install/uvm-install/Cargo.toml
@@ -4,6 +4,8 @@ version = "2.0.1"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 
 [dependencies]
+flexi_logger = "0.9.2"
+log = "0.4.5"
 console = "0.6.1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/install/uvm-install/Cargo.toml
+++ b/install/uvm-install/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 
 [dependencies]
 flexi_logger = "0.9.2"
+indicatif = "0.9.0"
 log = "0.4.5"
 console = "0.6.1"
 serde = "1.0"

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -5,34 +5,25 @@ extern crate serde;
 extern crate uvm_cli;
 extern crate uvm_core;
 extern crate uvm_install_core;
-extern crate indicatif;
 
-#[macro_use]
-extern crate log;
+use std::io::Write;
+use console::Term;
+use uvm_cli::ColorOption;
+use std::collections::HashSet;
+use uvm_core::unity::Version;
+use uvm_install_core::InstallVariant;
+use std::str::FromStr;
 
 use console::style;
-use console::Term;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle, ProgressDrawTarget};
-use std::collections::HashSet;
-use std::io;
-use std::io::Write;
-use std::path::{PathBuf,Path};
 use std::process;
-use std::str::FromStr;
-use std::thread;
-use std::time::Duration;
-use std::sync::{Arc, Mutex, Condvar};
-use uvm_cli::ColorOption;
+use std::io;
 use uvm_core::brew;
-use uvm_core::unity::{Installation,Version,Component};
-use uvm_install_core::InstallVariant;
 
 #[derive(Debug, Deserialize)]
 pub struct Options {
     #[serde(with = "uvm_core::unity::unity_version_format")]
     arg_version: Version,
     flag_verbose: bool,
-    flag_debug: bool,
     flag_android: bool,
     flag_ios: bool,
     flag_webgl: bool,
@@ -90,28 +81,15 @@ impl uvm_cli::Options for Options {
         self.flag_verbose
     }
 
-    fn debug(&self) -> bool {
-        self.flag_debug
-    }
-
     fn color(&self) -> &ColorOption {
         &self.flag_color
     }
-}
-
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
-struct InstallObject {
-    version: Version,
-    variant: InstallVariant,
-    destination: Option<PathBuf>
 }
 
 pub struct UvmCommand {
     stdout: Term,
     stderr: Term
 }
-
-type EditorInstallLock = Mutex<Option<io::Result<()>>>;
 
 impl UvmCommand {
     pub fn new() -> UvmCommand {
@@ -121,230 +99,57 @@ impl UvmCommand {
         }
     }
 
-    fn progress_draw_target<T>(options:&T) -> ProgressDrawTarget
-    where
-        T: uvm_cli::Options,
-    {
-        if( options.debug()) {
-            ProgressDrawTarget::hidden()
-        } else {
-            ProgressDrawTarget::stderr()
-        }
-    }
-
-    fn set_editor_install_lock(editor_installed_lock:&Arc<(EditorInstallLock,Condvar)>, value:io::Result<()>) {
-        let &(ref lock, ref cvar) = &**editor_installed_lock;
-        let mut is_installed = lock.lock().unwrap();
-        *is_installed = Some(value);
-        cvar.notify_all();
-    }
-
-    fn install(install_object:InstallObject, pb:ProgressBar, editor_installed_lock:Arc<(EditorInstallLock,Condvar)>) -> io::Result<()> {
-        pb.set_message("download installer");
-        let installer = uvm_install_core::download_installer(install_object.variant.clone(), &install_object.version)
-        .map_err(|error| {
-            debug!("error loading installer: {}", style(&error).red());
-            pb.finish_with_message(&format!("{}", style("error").red().bold()));
-            error
-        })?;
-
-        debug!("installer location: {}", &installer.display());
-
-        if install_object.variant != InstallVariant::Editor {
-            debug!("aquire editor install lock for {}", &install_object.variant);
-            let &(ref lock, ref cvar) = &*editor_installed_lock;
-            let mut is_installed = lock.lock().unwrap();
-            // As long as the value inside the `Mutex` is false, we wait.
-            while (*is_installed).is_none() {
-                pb.set_message("waiting for editor to finish installation");
-                debug!("waiting for editor to finish installation {}", &install_object.variant);
-                is_installed = cvar.wait(is_installed).unwrap();
-            }
-
-            if let Some(ref is_installed ) = *is_installed {
-                if let Err(err) = is_installed {
-                    debug!("editor installation error {}", &install_object.variant);
-                    pb.finish_with_message(&format!("{}", style("failed because editor failed").red().bold()));
-                    return Err(io::Error::new(io::ErrorKind::Other, format!("{} failed because of {}", &install_object.variant, InstallVariant::Editor)));
-                }
-                debug!("editor installation finish {}", &install_object.variant);
-            }
-        }
-
-        let destination = install_object.clone().destination.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "Missing installtion destination")
-        })?;
-
-        pb.set_message("installing");
-        debug!("install {} to {}",&install_object.variant, &destination.display());
-        let install_f = match &install_object.variant {
-            InstallVariant::Editor => uvm_install_core::installer::install_editor,
-                                 _ => uvm_install_core::installer::install_module,
-        };
-
-        install_f(&installer, &destination)
-        .map(|result| {
-            debug!("finishinstall {}.", &install_object.variant);
-            pb.finish_with_message("done");
-            if install_object.variant == InstallVariant::Editor {
-                UvmCommand::set_editor_install_lock(&editor_installed_lock, Ok(()));
-            }
-            result
-        })
-        .map_err(|error| {
-            debug!("failed to install {}. Error: {}", &install_object.variant, style(&error).red());
-            pb.finish_with_message(&format!("{}", style("failed to install").red().bold()));
-            if install_object.variant == InstallVariant::Editor {
-                let error = io::Error::new(io::ErrorKind::Other, "failed to install edit");
-                UvmCommand::set_editor_install_lock(&editor_installed_lock, Err(error));
-            }
-            error
-        })
-    }
-
     pub fn exec(&self, options:Options) -> io::Result<()> {
-        self.stderr.write_line(&format!("{}: {}", style("install unity version").green(), options.version().to_string())).ok();
+        write!(Term::stderr(), "{}: {}\n", style("install unity version").green(), options.version().to_string()).ok();
 
         uvm_install_core::ensure_tap_for_version(&options.version())?;
-        let installation = uvm_core::find_installation(&options.version());
 
-        let mut to_install:HashSet<InstallObject> = HashSet::new();
-        let mut installed:HashSet<InstallObject> = HashSet::new();
+        let casks = brew::cask::list()?;
+        let installed: HashSet<brew::cask::Cask> = casks
+            .filter(|cask| cask.contains(&format!("@{}", &options.version().to_string())))
+            .collect();
 
-        if installation.is_err() {
-            let base_dir = Path::new(&format!("/Applications/Unity-{}", options.version())).to_path_buf();
-            let installation_data = InstallObject {
-                            version: options.version().to_owned(),
-                            variant: InstallVariant::Editor,
-                            destination: Some(base_dir.to_path_buf()),
-                        };
-            to_install.insert(installation_data);
+        let mut to_install = HashSet::new();
+        to_install.insert(uvm_install_core::cask_name_for_type_version(
+            InstallVariant::Editor,
+            &options.version(),
+        ));
 
-            if let Some(variants) = options.install_variants() {
-                for variant in variants {
-                    let component:Component = variant.into();
-                    let variant_destination = component.installpath();
-                    let installation_data = InstallObject {
-                                    version: options.version().to_owned(),
-                                    variant: component.into(),
-                                    destination: variant_destination.map(|d| base_dir.join(d)),
-                                };
-                    to_install.insert(installation_data);
-                }
-            } else {
-               info!("No components requested to install");
+        if let Some(variants) = options.install_variants() {
+            for variant in variants {
+                to_install.insert(uvm_install_core::cask_name_for_type_version(variant, &options.version()));
             }
-        } else {
-            let installation = installation.unwrap();
-            info!("Editor already installed at {}", &installation.path().display());
-            let base_dir = installation.path();
-            if let Some(variants) = options.install_variants() {
-                for variant in variants {
-                    let component:Component = variant.into();
-                    let variant_destination = component.installpath();
-                    let installation_data = InstallObject {
-                                    version: options.version().to_owned(),
-                                    variant: component.into(),
-                                    destination: variant_destination.map(|d| base_dir.join(d))
-                                };
-                    to_install.insert(installation_data);
-                }
+        }
+
+        if options.flag_verbose {
+            write!(Term::stderr(), "{}\n", style("Casks to install:").green()).ok();
+            for c in &to_install {
+                write!(Term::stderr(), "{}\n", style(c).cyan()).ok();
             }
 
-            if !to_install.is_empty() {
-                for component in installation.installed_components() {
-                    let variant_destination = component.installpath();
-                    let installation_data = InstallObject {
-                                    version: options.version().to_owned(),
-                                    variant: component.into(),
-                                    destination: variant_destination.map(|d| base_dir.join(d))
-                                };
-                    installed.insert(installation_data);
+            let mut diff = to_install.union(&installed).peekable();
+            if let Some(_) = diff.peek() {
+                self.stderr.write_line("").ok();
+                write!(Term::stderr(), "{}\n", style("Skip variants already installed:").yellow()).ok();
+                for c in diff {
+                    write!(Term::stderr(), "{}\n", style(c).yellow().bold()).ok();
                 }
             }
         }
 
-        if to_install.is_empty() {
-            self.stderr.write_line(&format!("{}", style("Nothing to install").green())).ok();
-            return Ok(())
-        }
+        let mut diff = to_install.difference(&installed).peekable();
+        if let Some(_) = diff.peek() {
+            let mut child = brew::cask::install(diff)?;
+            let status = child.wait()?;
 
-        if log_enabled!(log::Level::Info) {
-            if !to_install.is_empty() {
-                info!("{}", style("Components to install:").green().bold());
-                for c in &to_install {
-                    info!("{}", style(&c.variant).yellow());
-                }
-            }
-
-            if !installed.is_empty() {
-                info!("{}", style("Components already installed:").green().bold());
-                for c in &installed {
-                    info!("{}", style(&c.variant).yellow());
-                }
-            }
-
-            let mut intersection = to_install.intersection(&installed).peekable();
-            if let Some(_) = intersection.peek() {
-                info!("{}", style("Skip variants already installed:").green().bold());
-                for c in intersection {
-                    info!("{}", style(&c.variant).yellow());
-                }
+            if !status.success() {
+                return Err(io::Error::new(io::ErrorKind::Other, "Failed to install casks"));
             }
         }
-
-        let mut diff = to_install.difference(&installed).cloned().peekable();
-        if let None = diff.peek() {
-            self.stderr.write_line(&format!("{}", style("Nothing to install").green())).ok();
-            return Ok(())
+        else {
+            return Err(io::Error::new(io::ErrorKind::Other, "Version and all support packages already installed"));
         }
 
-        let multiProgress = MultiProgress::new();
-        multiProgress.set_draw_target(UvmCommand::progress_draw_target(&options));
-        let sty = ProgressStyle::default_bar()
-            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ ")
-            .template("{prefix:.bold.dim>15} {spinner} {wide_msg}");
-
-        let mut threads:Vec<thread::JoinHandle<io::Result<()>>> = Vec::new();
-        let editor_installed_lock = Arc::new((Mutex::new(None), Condvar::new()));
-        let mut editor_installing = false;
-        for install_object in diff {
-            let pb = multiProgress.add(ProgressBar::new(1));
-            pb.set_style(sty.clone());
-            pb.enable_steady_tick(100);
-            pb.tick();
-            pb.set_prefix(&format!("{}", install_object.variant));
-            let editor_installed_lock_c = editor_installed_lock.clone();
-            editor_installing |= install_object.variant == InstallVariant::Editor;
-            threads.push(
-                thread::spawn(move || {
-                    UvmCommand::install(install_object, pb, editor_installed_lock_c)
-                })
-            );
-        }
-
-        if !editor_installing {
-            UvmCommand::set_editor_install_lock(&editor_installed_lock, Ok(()));
-        }
-
-        //wait for all progress bars to finish
-        multiProgress.join_and_clear();
-        threads.into_iter()
-        .map(thread::JoinHandle::join)
-        .map(|thread_result| {
-            match thread_result {
-                Ok(x) => x,
-                Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Install thread failed"))
-            }
-        })
-        .fold(Ok(()), |acc, r| {
-            if let Err(x) = r {
-                if let Err(y) = acc {
-                    return Err(io::Error::new(io::ErrorKind::Other, format!("{}\n{}", y, x)))
-                }
-                return Err(io::Error::new(io::ErrorKind::Other, x))
-            }
-            acc
-        })
+        Ok(())
     }
 }

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -198,14 +198,18 @@ impl UvmCommand {
         }
 
         if log_enabled!(log::Level::Info) {
-            info!("{}", style("Components to install:").green().bold());
-            for c in &to_install {
-                info!("{}", style(&c.variant).yellow());
+            if !to_install.is_empty() {
+                info!("{}", style("Components to install:").green().bold());
+                for c in &to_install {
+                    info!("{}", style(&c.variant).yellow());
+                }
             }
 
-            info!("{}", style("Components already installed:").green().bold());
-            for c in &installed {
-                info!("{}", style(&c.variant).yellow());
+            if !installed.is_empty() {
+                info!("{}", style("Components already installed:").green().bold());
+                for c in &installed {
+                    info!("{}", style(&c.variant).yellow());
+                }
             }
 
             let mut intersection = to_install.intersection(&installed).peekable();

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -6,6 +6,9 @@ extern crate uvm_cli;
 extern crate uvm_core;
 extern crate uvm_install_core;
 
+#[macro_use]
+extern crate log;
+
 use std::io::Write;
 use console::Term;
 use uvm_cli::ColorOption;
@@ -100,7 +103,7 @@ impl UvmCommand {
     }
 
     pub fn exec(&self, options:Options) -> io::Result<()> {
-        write!(Term::stderr(), "{}: {}\n", style("install unity version").green(), options.version().to_string()).ok();
+        self.stderr.write_line(&format!("{}: {}", style("install unity version").green(), options.version().to_string())).ok();
 
         uvm_install_core::ensure_tap_for_version(&options.version())?;
 
@@ -121,18 +124,18 @@ impl UvmCommand {
             }
         }
 
-        if options.flag_verbose {
-            write!(Term::stderr(), "{}\n", style("Casks to install:").green()).ok();
+        if log_enabled!(log::Level::Info) {
+            info!("{}", style("Casks to install:").green());
             for c in &to_install {
-                write!(Term::stderr(), "{}\n", style(c).cyan()).ok();
+                info!("{}", style(c).cyan());
             }
 
             let mut diff = to_install.union(&installed).peekable();
             if let Some(_) = diff.peek() {
-                self.stderr.write_line("").ok();
-                write!(Term::stderr(), "{}\n", style("Skip variants already installed:").yellow()).ok();
+                info!("");
+                info!("{}", style("Skip variants already installed:").yellow());
                 for c in diff {
-                    write!(Term::stderr(), "{}\n", style(c).yellow().bold()).ok();
+                    info!("{}", style(c).yellow().bold());
                 }
             }
         }

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -176,7 +176,12 @@ impl UvmCommand {
             }
         }
 
-        let mut diff = to_install.difference(&installed).cloned();//.peekable();
+        let mut diff = to_install.difference(&installed).cloned().peekable();
+        if let None = diff.peek() {
+            self.stderr.write_line(&format!("{}", style("Nothing to install").green())).ok();
+            return Ok(())
+        }
+
         // if let Some(_) = diff.peek() {
         //     let mut child = brew::cask::install(diff)?;
         //     let status = child.wait()?;

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Options {
     #[serde(with = "uvm_core::unity::unity_version_format")]
     arg_version: Version,
     flag_verbose: bool,
+    flag_debug: bool,
     flag_android: bool,
     flag_ios: bool,
     flag_webgl: bool,
@@ -82,6 +83,10 @@ impl Options {
 impl uvm_cli::Options for Options {
     fn verbose(&self) -> bool {
         self.flag_verbose
+    }
+
+    fn debug(&self) -> bool {
+        self.flag_debug
     }
 
     fn color(&self) -> &ColorOption {

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -126,6 +126,9 @@ impl UvmCommand {
         self.stderr.write_line(&format!("{}: {}", style("install unity version").green(), options.version().to_string())).ok();
 
         uvm_install_core::ensure_tap_for_version(&options.version())?;
+        let installation  = uvm_core::find_installation(&options.version())?;
+
+
         //let casks = brew::cask::list()?;
         // let installed: HashSet<brew::cask::Cask> = casks
         //     .filter(|cask| cask.contains(&format!("@{}", &options.version().to_string())))

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -1,0 +1,155 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate console;
+extern crate serde;
+extern crate uvm_cli;
+extern crate uvm_core;
+extern crate uvm_install_core;
+
+use std::io::Write;
+use console::Term;
+use uvm_cli::ColorOption;
+use std::collections::HashSet;
+use uvm_core::unity::Version;
+use uvm_install_core::InstallVariant;
+use std::str::FromStr;
+
+use console::style;
+use std::process;
+use std::io;
+use uvm_core::brew;
+
+#[derive(Debug, Deserialize)]
+pub struct Options {
+    #[serde(with = "uvm_core::unity::unity_version_format")]
+    arg_version: Version,
+    flag_verbose: bool,
+    flag_android: bool,
+    flag_ios: bool,
+    flag_webgl: bool,
+    flag_mobile: bool,
+    flag_linux: bool,
+    flag_windows: bool,
+    flag_desktop: bool,
+    flag_all: bool,
+    flag_color: ColorOption,
+}
+
+impl Options {
+    pub fn version(&self) -> &Version {
+        &self.arg_version
+    }
+
+    pub fn install_variants(&self) -> Option<HashSet<InstallVariant>> {
+        if self.flag_android || self.flag_ios || self.flag_webgl || self.flag_linux
+            || self.flag_windows || self.flag_mobile || self.flag_desktop || self.flag_all
+        {
+            let mut variants: HashSet<InstallVariant> = HashSet::with_capacity(5);
+
+            if self.flag_android || self.flag_mobile || self.flag_all {
+                variants.insert(InstallVariant::Android);
+            }
+
+            if self.flag_ios || self.flag_mobile || self.flag_all {
+                variants.insert(InstallVariant::Ios);
+            }
+
+            if self.flag_webgl || self.flag_mobile || self.flag_all {
+                variants.insert(InstallVariant::WebGl);
+            }
+
+            let check_version = Version::from_str("2018.0.0b0").unwrap();
+            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() >= &check_version {
+                variants.insert(InstallVariant::WindowsMono);
+            }
+
+            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() < &check_version {
+                variants.insert(InstallVariant::Windows);
+            }
+
+            if self.flag_linux || self.flag_desktop || self.flag_all {
+                variants.insert(InstallVariant::Linux);
+            }
+            return Some(variants);
+        }
+        None
+    }
+}
+
+impl uvm_cli::Options for Options {
+    fn verbose(&self) -> bool {
+        self.flag_verbose
+    }
+
+    fn color(&self) -> &ColorOption {
+        &self.flag_color
+    }
+}
+
+pub struct UvmCommand {
+    stdout: Term,
+    stderr: Term
+}
+
+impl UvmCommand {
+    pub fn new() -> UvmCommand {
+        UvmCommand {
+            stdout: Term::stdout(),
+            stderr: Term::stderr(),
+        }
+    }
+
+    pub fn exec(&self, options:Options) -> io::Result<()> {
+        write!(Term::stderr(), "{}: {}\n", style("install unity version").green(), options.version().to_string()).ok();
+
+        uvm_install_core::ensure_tap_for_version(&options.version())?;
+
+        let casks = brew::cask::list()?;
+        let installed: HashSet<brew::cask::Cask> = casks
+            .filter(|cask| cask.contains(&format!("@{}", &options.version().to_string())))
+            .collect();
+
+        let mut to_install = HashSet::new();
+        to_install.insert(uvm_install_core::cask_name_for_type_version(
+            InstallVariant::Editor,
+            &options.version(),
+        ));
+
+        if let Some(variants) = options.install_variants() {
+            for variant in variants {
+                to_install.insert(uvm_install_core::cask_name_for_type_version(variant, &options.version()));
+            }
+        }
+
+        if options.flag_verbose {
+            write!(Term::stderr(), "{}\n", style("Casks to install:").green()).ok();
+            for c in &to_install {
+                write!(Term::stderr(), "{}\n", style(c).cyan()).ok();
+            }
+
+            let mut diff = to_install.union(&installed).peekable();
+            if let Some(_) = diff.peek() {
+                self.stderr.write_line("").ok();
+                write!(Term::stderr(), "{}\n", style("Skip variants already installed:").yellow()).ok();
+                for c in diff {
+                    write!(Term::stderr(), "{}\n", style(c).yellow().bold()).ok();
+                }
+            }
+        }
+
+        let mut diff = to_install.difference(&installed).peekable();
+        if let Some(_) = diff.peek() {
+            let mut child = brew::cask::install(diff)?;
+            let status = child.wait()?;
+
+            if !status.success() {
+                return Err(io::Error::new(io::ErrorKind::Other, "Failed to install casks"));
+            }
+        }
+        else {
+            return Err(io::Error::new(io::ErrorKind::Other, "Version and all support packages already installed"));
+        }
+
+        Ok(())
+    }
+}

--- a/install/uvm-install/src/main.rs
+++ b/install/uvm-install/src/main.rs
@@ -1,24 +1,13 @@
 #[macro_use]
-extern crate serde_derive;
-extern crate console;
-extern crate serde;
 extern crate uvm_cli;
-extern crate uvm_core;
-extern crate uvm_install_core;
-
-use std::io::Write;
-use console::Term;
-use uvm_cli::Options;
-use uvm_cli::ColorOption;
-use std::collections::HashSet;
-use uvm_core::unity::Version;
-use uvm_install_core::InstallVariant;
-use std::str::FromStr;
+extern crate uvm_install;
+extern crate flexi_logger;
+extern crate console;
 
 use console::style;
 use std::process;
-use std::io;
-use uvm_core::brew;
+use console::Term;
+use std::io::Write;
 
 const USAGE: &'static str = "
 uvm-install - Install specified unity version.
@@ -41,137 +30,16 @@ Options:
   -h, --help        show this help message and exit
 ";
 
-#[derive(Debug, Deserialize)]
-struct InstallOptions {
-    #[serde(with = "uvm_core::unity::unity_version_format")]
-    arg_version: Version,
-    flag_verbose: bool,
-    flag_android: bool,
-    flag_ios: bool,
-    flag_webgl: bool,
-    flag_mobile: bool,
-    flag_linux: bool,
-    flag_windows: bool,
-    flag_desktop: bool,
-    flag_all: bool,
-    flag_color: ColorOption,
-}
-
-impl InstallOptions {
-    pub fn version(&self) -> &Version {
-        &self.arg_version
-    }
-
-    pub fn install_variants(&self) -> Option<HashSet<InstallVariant>> {
-        if self.flag_android || self.flag_ios || self.flag_webgl || self.flag_linux
-            || self.flag_windows || self.flag_mobile || self.flag_desktop || self.flag_all
-        {
-            let mut variants: HashSet<InstallVariant> = HashSet::with_capacity(5);
-
-            if self.flag_android || self.flag_mobile || self.flag_all {
-                variants.insert(InstallVariant::Android);
-            }
-
-            if self.flag_ios || self.flag_mobile || self.flag_all {
-                variants.insert(InstallVariant::Ios);
-            }
-
-            if self.flag_webgl || self.flag_mobile || self.flag_all {
-                variants.insert(InstallVariant::WebGl);
-            }
-
-            let check_version = Version::from_str("2018.0.0b0").unwrap();
-            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() >= &check_version {
-                variants.insert(InstallVariant::WindowsMono);
-            }
-
-            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() < &check_version {
-                variants.insert(InstallVariant::Windows);
-            }
-
-            if self.flag_linux || self.flag_desktop || self.flag_all {
-                variants.insert(InstallVariant::Linux);
-            }
-            return Some(variants);
-        }
-        None
-    }
-}
-
-impl Options for InstallOptions {
-    fn verbose(&self) -> bool {
-        self.flag_verbose
-    }
-
-    fn color(&self) -> &ColorOption {
-        &self.flag_color
-    }
-}
-
-fn main() {
+fn main() -> std::io::Result<()> {
     let mut stdout = Term::stderr();
-    install(uvm_cli::get_options(USAGE).unwrap()).unwrap_or_else(|err| {
-        let message = format!("Unable to install");
-        write!(stdout, "{}\n", style(message).red()).ok();
-        write!(stdout, "{}\n", style(err).red()).ok();
-        process::exit(1);
-    });
+    let options:uvm_install::Options = uvm_cli::get_options(USAGE)?;
+    uvm_install::UvmCommand::new().exec(options)
+        .unwrap_or_else(|err| {
+            let message = format!("Unable to install");
+            write!(stdout, "{}\n", style(message).red()).ok();
+            write!(stdout, "{}\n", style(err).red()).ok();
+            process::exit(1);
+        });
 
-    stdout.write_line("Finish").ok();
-}
-
-fn install(options: InstallOptions) -> io::Result<()> {
-    let mut stderr = Term::stderr();
-    write!(stderr, "{}: {}\n", style("install unity version").green(), options.version().to_string()).ok();
-
-
-    uvm_install_core::ensure_tap_for_version(&options.version())?;
-
-    let casks = brew::cask::list()?;
-    let installed: HashSet<brew::cask::Cask> = casks
-        .filter(|cask| cask.contains(&format!("@{}", &options.version().to_string())))
-        .collect();
-
-    let mut to_install = HashSet::new();
-    to_install.insert(uvm_install_core::cask_name_for_type_version(
-        InstallVariant::Editor,
-        &options.version(),
-    ));
-
-    if let Some(variants) = options.install_variants() {
-        for variant in variants {
-            to_install.insert(uvm_install_core::cask_name_for_type_version(variant, &options.version()));
-        }
-    }
-
-    if options.verbose() {
-        write!(stderr, "{}\n", style("Casks to install:").green()).ok();
-        for c in &to_install {
-            write!(stderr, "{}\n", style(c).cyan()).ok();
-        }
-
-        let mut diff = to_install.intersection(&installed).peekable();
-        if let Some(_) = diff.peek() {
-            stderr.write_line("").ok();
-            write!(stderr, "{}\n", style("Skip variants already installed:").yellow()).ok();
-            for c in diff {
-                write!(stderr, "{}\n", style(c).yellow().bold()).ok();
-            }
-        }
-    }
-
-    let mut diff = to_install.difference(&installed).peekable();
-    if let Some(_) = diff.peek() {
-        let mut child = brew::cask::install(diff)?;
-        let status = child.wait()?;
-
-        if !status.success() {
-            return Err(io::Error::new(io::ErrorKind::Other, "Failed to install casks"));
-        }
-    }
-    else {
-        return Err(io::Error::new(io::ErrorKind::Other, "Version and all support packages already installed"));
-    }
-
-    Ok(())
+    stdout.write_line("Finish")
 }

--- a/install/uvm-install/src/main.rs
+++ b/install/uvm-install/src/main.rs
@@ -25,6 +25,7 @@ Options:
   --windows         install windows support for editor
   --desktop         install desktop support (linux, windows)
   -v, --verbose     print more output
+  -d, --debug       print debug output
   --color WHEN      Coloring: auto, always, never [default: auto]
   -h, --help        show this help message and exit
 ";

--- a/install/uvm-install/src/main.rs
+++ b/install/uvm-install/src/main.rs
@@ -7,7 +7,6 @@ extern crate console;
 use console::style;
 use std::process;
 use console::Term;
-use std::io::Write;
 
 const USAGE: &'static str = "
 uvm-install - Install specified unity version.
@@ -31,13 +30,13 @@ Options:
 ";
 
 fn main() -> std::io::Result<()> {
-    let mut stdout = Term::stderr();
+    let stdout = Term::stderr();
     let options:uvm_install::Options = uvm_cli::get_options(USAGE)?;
     uvm_install::UvmCommand::new().exec(options)
         .unwrap_or_else(|err| {
             let message = format!("Unable to install");
-            write!(stdout, "{}\n", style(message).red()).ok();
-            write!(stdout, "{}\n", style(err).red()).ok();
+            stdout.write_line(&format!("{}",style(message).red())).ok();
+            stdout.write_line(&format!("{}",style(err).red())).ok();
             process::exit(1);
         });
 

--- a/install/uvm-install/src/main.rs
+++ b/install/uvm-install/src/main.rs
@@ -4,6 +4,9 @@ extern crate uvm_install;
 extern crate flexi_logger;
 extern crate console;
 
+#[macro_use]
+extern crate log;
+
 use console::style;
 use std::process;
 use console::Term;
@@ -35,11 +38,11 @@ fn main() -> std::io::Result<()> {
     let options:uvm_install::Options = uvm_cli::get_options(USAGE)?;
     uvm_install::UvmCommand::new().exec(options)
         .unwrap_or_else(|err| {
-            let message = format!("Unable to install");
+            let message = format!("Failure during installation");
             stdout.write_line(&format!("{}",style(message).red())).ok();
-            stdout.write_line(&format!("{}",style(err).red())).ok();
+            info!("{}", &format!("{}",style(err).red()));
             process::exit(1);
         });
 
-    stdout.write_line("Finish")
+    stdout.write_line(&format!("{}", style("Finish").green().bold()))
 }

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name = "uvm-install"
+name = "uvm-install2"
 version = "2.0.1"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 
 [dependencies]
 flexi_logger = "0.9.2"
+indicatif = "0.9.0"
 log = "0.4.5"
 console = "0.6.1"
 serde = "1.0"

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -1,0 +1,350 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate console;
+extern crate serde;
+extern crate uvm_cli;
+extern crate uvm_core;
+extern crate uvm_install_core;
+extern crate indicatif;
+
+#[macro_use]
+extern crate log;
+
+use console::style;
+use console::Term;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle, ProgressDrawTarget};
+use std::collections::HashSet;
+use std::io;
+use std::io::Write;
+use std::path::{PathBuf,Path};
+use std::process;
+use std::str::FromStr;
+use std::thread;
+use std::time::Duration;
+use std::sync::{Arc, Mutex, Condvar};
+use uvm_cli::ColorOption;
+use uvm_core::brew;
+use uvm_core::unity::{Installation,Version,Component};
+use uvm_install_core::InstallVariant;
+
+#[derive(Debug, Deserialize)]
+pub struct Options {
+    #[serde(with = "uvm_core::unity::unity_version_format")]
+    arg_version: Version,
+    flag_verbose: bool,
+    flag_debug: bool,
+    flag_android: bool,
+    flag_ios: bool,
+    flag_webgl: bool,
+    flag_mobile: bool,
+    flag_linux: bool,
+    flag_windows: bool,
+    flag_desktop: bool,
+    flag_all: bool,
+    flag_color: ColorOption,
+}
+
+impl Options {
+    pub fn version(&self) -> &Version {
+        &self.arg_version
+    }
+
+    pub fn install_variants(&self) -> Option<HashSet<InstallVariant>> {
+        if self.flag_android || self.flag_ios || self.flag_webgl || self.flag_linux
+            || self.flag_windows || self.flag_mobile || self.flag_desktop || self.flag_all
+        {
+            let mut variants: HashSet<InstallVariant> = HashSet::with_capacity(5);
+
+            if self.flag_android || self.flag_mobile || self.flag_all {
+                variants.insert(InstallVariant::Android);
+            }
+
+            if self.flag_ios || self.flag_mobile || self.flag_all {
+                variants.insert(InstallVariant::Ios);
+            }
+
+            if self.flag_webgl || self.flag_mobile || self.flag_all {
+                variants.insert(InstallVariant::WebGl);
+            }
+
+            let check_version = Version::from_str("2018.0.0b0").unwrap();
+            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() >= &check_version {
+                variants.insert(InstallVariant::WindowsMono);
+            }
+
+            if (self.flag_windows || self.flag_desktop || self.flag_all) && self.version() < &check_version {
+                variants.insert(InstallVariant::Windows);
+            }
+
+            if self.flag_linux || self.flag_desktop || self.flag_all {
+                variants.insert(InstallVariant::Linux);
+            }
+            return Some(variants);
+        }
+        None
+    }
+}
+
+impl uvm_cli::Options for Options {
+    fn verbose(&self) -> bool {
+        self.flag_verbose
+    }
+
+    fn debug(&self) -> bool {
+        self.flag_debug
+    }
+
+    fn color(&self) -> &ColorOption {
+        &self.flag_color
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+struct InstallObject {
+    version: Version,
+    variant: InstallVariant,
+    destination: Option<PathBuf>
+}
+
+pub struct UvmCommand {
+    stdout: Term,
+    stderr: Term
+}
+
+type EditorInstallLock = Mutex<Option<io::Result<()>>>;
+
+impl UvmCommand {
+    pub fn new() -> UvmCommand {
+        UvmCommand {
+            stdout: Term::stdout(),
+            stderr: Term::stderr(),
+        }
+    }
+
+    fn progress_draw_target<T>(options:&T) -> ProgressDrawTarget
+    where
+        T: uvm_cli::Options,
+    {
+        if( options.debug()) {
+            ProgressDrawTarget::hidden()
+        } else {
+            ProgressDrawTarget::stderr()
+        }
+    }
+
+    fn set_editor_install_lock(editor_installed_lock:&Arc<(EditorInstallLock,Condvar)>, value:io::Result<()>) {
+        let &(ref lock, ref cvar) = &**editor_installed_lock;
+        let mut is_installed = lock.lock().unwrap();
+        *is_installed = Some(value);
+        cvar.notify_all();
+    }
+
+    fn install(install_object:InstallObject, pb:ProgressBar, editor_installed_lock:Arc<(EditorInstallLock,Condvar)>) -> io::Result<()> {
+        pb.set_message("download installer");
+        let installer = uvm_install_core::download_installer(install_object.variant.clone(), &install_object.version)
+        .map_err(|error| {
+            debug!("error loading installer: {}", style(&error).red());
+            pb.finish_with_message(&format!("{}", style("error").red().bold()));
+            error
+        })?;
+
+        debug!("installer location: {}", &installer.display());
+
+        if install_object.variant != InstallVariant::Editor {
+            debug!("aquire editor install lock for {}", &install_object.variant);
+            let &(ref lock, ref cvar) = &*editor_installed_lock;
+            let mut is_installed = lock.lock().unwrap();
+            // As long as the value inside the `Mutex` is false, we wait.
+            while (*is_installed).is_none() {
+                pb.set_message("waiting for editor to finish installation");
+                debug!("waiting for editor to finish installation {}", &install_object.variant);
+                is_installed = cvar.wait(is_installed).unwrap();
+            }
+
+            if let Some(ref is_installed ) = *is_installed {
+                if let Err(err) = is_installed {
+                    debug!("editor installation error {}", &install_object.variant);
+                    pb.finish_with_message(&format!("{}", style("failed because editor failed").red().bold()));
+                    return Err(io::Error::new(io::ErrorKind::Other, format!("{} failed because of {}", &install_object.variant, InstallVariant::Editor)));
+                }
+                debug!("editor installation finish {}", &install_object.variant);
+            }
+        }
+
+        let destination = install_object.clone().destination.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "Missing installtion destination")
+        })?;
+
+        pb.set_message("installing");
+        debug!("install {} to {}",&install_object.variant, &destination.display());
+        let install_f = match &install_object.variant {
+            InstallVariant::Editor => uvm_install_core::installer::install_editor,
+                                 _ => uvm_install_core::installer::install_module,
+        };
+
+        install_f(&installer, &destination)
+        .map(|result| {
+            debug!("finishinstall {}.", &install_object.variant);
+            pb.finish_with_message("done");
+            if install_object.variant == InstallVariant::Editor {
+                UvmCommand::set_editor_install_lock(&editor_installed_lock, Ok(()));
+            }
+            result
+        })
+        .map_err(|error| {
+            debug!("failed to install {}. Error: {}", &install_object.variant, style(&error).red());
+            pb.finish_with_message(&format!("{}", style("failed to install").red().bold()));
+            if install_object.variant == InstallVariant::Editor {
+                let error = io::Error::new(io::ErrorKind::Other, "failed to install edit");
+                UvmCommand::set_editor_install_lock(&editor_installed_lock, Err(error));
+            }
+            error
+        })
+    }
+
+    pub fn exec(&self, options:Options) -> io::Result<()> {
+        self.stderr.write_line(&format!("{}: {}", style("install unity version").green(), options.version().to_string())).ok();
+
+        uvm_install_core::ensure_tap_for_version(&options.version())?;
+        let installation = uvm_core::find_installation(&options.version());
+
+        let mut to_install:HashSet<InstallObject> = HashSet::new();
+        let mut installed:HashSet<InstallObject> = HashSet::new();
+
+        if installation.is_err() {
+            let base_dir = Path::new(&format!("/Applications/Unity-{}", options.version())).to_path_buf();
+            let installation_data = InstallObject {
+                            version: options.version().to_owned(),
+                            variant: InstallVariant::Editor,
+                            destination: Some(base_dir.to_path_buf()),
+                        };
+            to_install.insert(installation_data);
+
+            if let Some(variants) = options.install_variants() {
+                for variant in variants {
+                    let component:Component = variant.into();
+                    let variant_destination = component.installpath();
+                    let installation_data = InstallObject {
+                                    version: options.version().to_owned(),
+                                    variant: component.into(),
+                                    destination: variant_destination.map(|d| base_dir.join(d)),
+                                };
+                    to_install.insert(installation_data);
+                }
+            } else {
+               info!("No components requested to install");
+            }
+        } else {
+            let installation = installation.unwrap();
+            info!("Editor already installed at {}", &installation.path().display());
+            let base_dir = installation.path();
+            if let Some(variants) = options.install_variants() {
+                for variant in variants {
+                    let component:Component = variant.into();
+                    let variant_destination = component.installpath();
+                    let installation_data = InstallObject {
+                                    version: options.version().to_owned(),
+                                    variant: component.into(),
+                                    destination: variant_destination.map(|d| base_dir.join(d))
+                                };
+                    to_install.insert(installation_data);
+                }
+            }
+
+            if !to_install.is_empty() {
+                for component in installation.installed_components() {
+                    let variant_destination = component.installpath();
+                    let installation_data = InstallObject {
+                                    version: options.version().to_owned(),
+                                    variant: component.into(),
+                                    destination: variant_destination.map(|d| base_dir.join(d))
+                                };
+                    installed.insert(installation_data);
+                }
+            }
+        }
+
+        if to_install.is_empty() {
+            self.stderr.write_line(&format!("{}", style("Nothing to install").green())).ok();
+            return Ok(())
+        }
+
+        if log_enabled!(log::Level::Info) {
+            if !to_install.is_empty() {
+                info!("{}", style("Components to install:").green().bold());
+                for c in &to_install {
+                    info!("{}", style(&c.variant).yellow());
+                }
+            }
+
+            if !installed.is_empty() {
+                info!("{}", style("Components already installed:").green().bold());
+                for c in &installed {
+                    info!("{}", style(&c.variant).yellow());
+                }
+            }
+
+            let mut intersection = to_install.intersection(&installed).peekable();
+            if let Some(_) = intersection.peek() {
+                info!("{}", style("Skip variants already installed:").green().bold());
+                for c in intersection {
+                    info!("{}", style(&c.variant).yellow());
+                }
+            }
+        }
+
+        let mut diff = to_install.difference(&installed).cloned().peekable();
+        if let None = diff.peek() {
+            self.stderr.write_line(&format!("{}", style("Nothing to install").green())).ok();
+            return Ok(())
+        }
+
+        let multiProgress = MultiProgress::new();
+        multiProgress.set_draw_target(UvmCommand::progress_draw_target(&options));
+        let sty = ProgressStyle::default_bar()
+            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ ")
+            .template("{prefix:.bold.dim>15} {spinner} {wide_msg}");
+
+        let mut threads:Vec<thread::JoinHandle<io::Result<()>>> = Vec::new();
+        let editor_installed_lock = Arc::new((Mutex::new(None), Condvar::new()));
+        let mut editor_installing = false;
+        for install_object in diff {
+            let pb = multiProgress.add(ProgressBar::new(1));
+            pb.set_style(sty.clone());
+            pb.enable_steady_tick(100);
+            pb.tick();
+            pb.set_prefix(&format!("{}", install_object.variant));
+            let editor_installed_lock_c = editor_installed_lock.clone();
+            editor_installing |= install_object.variant == InstallVariant::Editor;
+            threads.push(
+                thread::spawn(move || {
+                    UvmCommand::install(install_object, pb, editor_installed_lock_c)
+                })
+            );
+        }
+
+        if !editor_installing {
+            UvmCommand::set_editor_install_lock(&editor_installed_lock, Ok(()));
+        }
+
+        //wait for all progress bars to finish
+        multiProgress.join_and_clear();
+        threads.into_iter()
+        .map(thread::JoinHandle::join)
+        .map(|thread_result| {
+            match thread_result {
+                Ok(x) => x,
+                Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Install thread failed"))
+            }
+        })
+        .fold(Ok(()), |acc, r| {
+            if let Err(x) = r {
+                if let Err(y) = acc {
+                    return Err(io::Error::new(io::ErrorKind::Other, format!("{}\n{}", y, x)))
+                }
+                return Err(io::Error::new(io::ErrorKind::Other, x))
+            }
+            acc
+        })
+    }
+}

--- a/install/uvm-install2/src/main.rs
+++ b/install/uvm-install2/src/main.rs
@@ -1,20 +1,22 @@
 #[macro_use]
 extern crate uvm_cli;
-extern crate uvm_install;
+extern crate uvm_install2;
 extern crate flexi_logger;
 extern crate console;
+
+#[macro_use]
+extern crate log;
 
 use console::style;
 use std::process;
 use console::Term;
-use std::io::Write;
 
 const USAGE: &'static str = "
-uvm-install - Install specified unity version.
+uvm-install2 - Install specified unity version.
 
 Usage:
-  uvm-install [options] <version>
-  uvm-install (-h | --help)
+  uvm-install2 [options] <version>
+  uvm-install2 (-h | --help)
 
 Options:
   -a, --all         install all support packages
@@ -26,20 +28,21 @@ Options:
   --windows         install windows support for editor
   --desktop         install desktop support (linux, windows)
   -v, --verbose     print more output
+  -d, --debug       print debug output
   --color WHEN      Coloring: auto, always, never [default: auto]
   -h, --help        show this help message and exit
 ";
 
 fn main() -> std::io::Result<()> {
-    let mut stdout = Term::stderr();
-    let options:uvm_install::Options = uvm_cli::get_options(USAGE)?;
-    uvm_install::UvmCommand::new().exec(options)
+    let stdout = Term::stderr();
+    let options:uvm_install2::Options = uvm_cli::get_options(USAGE)?;
+    uvm_install2::UvmCommand::new().exec(options)
         .unwrap_or_else(|err| {
-            let message = format!("Unable to install");
-            write!(stdout, "{}\n", style(message).red()).ok();
-            write!(stdout, "{}\n", style(err).red()).ok();
+            let message = format!("Failure during installation");
+            stdout.write_line(&format!("{}",style(message).red())).ok();
+            info!("{}", &format!("{}",style(err).red()));
             process::exit(1);
         });
 
-    stdout.write_line("Finish")
+    stdout.write_line(&format!("{}", style("Finish").green().bold()))
 }

--- a/install/uvm-install2/src/main.rs
+++ b/install/uvm-install2/src/main.rs
@@ -15,7 +15,7 @@ const USAGE: &'static str = "
 uvm-install2 - Install specified unity version.
 
 Usage:
-  uvm-install2 [options] <version>
+  uvm-install2 [options] <version> [<destination>]
   uvm-install2 (-h | --help)
 
 Options:
@@ -31,6 +31,10 @@ Options:
   -d, --debug       print debug output
   --color WHEN      Coloring: auto, always, never [default: auto]
   -h, --help        show this help message and exit
+
+Arguments:
+  <version>         The unity version to install in the form of `2018.1.0f3`
+  <destination>     A directory to install the requested version to
 ";
 
 fn main() -> std::io::Result<()> {

--- a/install/uvm_install_core/Cargo.toml
+++ b/install/uvm_install_core/Cargo.toml
@@ -5,4 +5,6 @@ authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 
 [dependencies]
 uvm_core = { path = "../../uvm_core" }
+regex = "1.0"
 log = "0.4.5"
+futures = "0.1.25"

--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -53,6 +53,20 @@ impl From<Component> for InstallVariant {
     }
 }
 
+impl From<InstallVariant> for Component {
+    fn from(component: InstallVariant) -> Self {
+        match component {
+            InstallVariant::Android => Component::Android,
+            InstallVariant::Ios => Component::Ios,
+            InstallVariant::WebGl => Component::WebGl,
+            InstallVariant::Linux => Component::Linux,
+            InstallVariant::Windows => Component::Windows,
+            InstallVariant::WindowsMono => Component::WindowsMono,
+            InstallVariant::Editor => Component::Editor
+        }
+    }
+}
+
 fn fetch_download_path_from_output(output: &Vec<u8>) -> Option<PathBuf> {
     let url_pattern = Regex::new(r"^==> Success! Downloaded to -> (.*)$").unwrap();
     String::from_utf8_lossy(output).lines().find(|line| {

--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -1,12 +1,16 @@
 extern crate uvm_core;
 #[macro_use]
 extern crate log;
+extern crate regex;
 
 use std::fmt;
 use std::io;
 use uvm_core::brew;
 use uvm_core::unity::Version;
 use uvm_core::unity::VersionType;
+use std::path::PathBuf;
+use std::path::Path;
+use regex::Regex;
 
 pub mod installer;
 
@@ -33,6 +37,35 @@ impl fmt::Display for InstallVariant {
             _ => write!(f, "editor"),
         }
     }
+}
+
+fn fetch_download_path_from_output(output: &Vec<u8>) -> Option<PathBuf> {
+    let url_pattern = Regex::new(r"^==> Success! Downloaded to -> (.*)$").unwrap();
+    String::from_utf8_lossy(output).lines().find(|line| {
+        url_pattern.is_match(line)
+    }).map(|line| {
+        let caps = url_pattern.captures(line).unwrap();
+        Path::new(&caps.get(1).unwrap().as_str()).to_path_buf()
+    })
+}
+
+pub fn download_installer(variant: InstallVariant, version: &Version) -> io::Result<PathBuf> {
+    debug!("download installer for variant: {} and version: {}", variant, version);
+    let cask = cask_name_for_type_version(variant, version);
+    let child = brew::cask::fetch(vec!(cask), true)?;
+    let o = child.wait_with_output()?;
+
+    if !o.status.success() {
+        //error!("{}", String::from_utf8_lossy(&o.stderr));
+        return Err(io::Error::new(io::ErrorKind::Other, "Failed to download installer"));
+    }
+
+    trace!("stderr:\n{}", String::from_utf8_lossy(&o.stderr));
+    trace!("stdout:\n{}", String::from_utf8_lossy(&o.stdout));
+
+    fetch_download_path_from_output(&o.stdout).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::Other, format!("Failed to fetch installer url \n{}", String::from_utf8_lossy(&o.stdout)))
+    })
 }
 
 pub fn ensure_tap_for_version(version: &Version) -> io::Result<()> {

--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -11,7 +11,7 @@ use uvm_core::unity::VersionType;
 use std::path::PathBuf;
 use std::path::Path;
 use regex::Regex;
-
+use uvm_core::unity::Component;
 pub mod installer;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
@@ -35,6 +35,20 @@ impl fmt::Display for InstallVariant {
             &InstallVariant::Windows => write!(f, "windows"),
             &InstallVariant::WindowsMono => write!(f, "windows-mono"),
             _ => write!(f, "editor"),
+        }
+    }
+}
+
+impl From<Component> for InstallVariant {
+    fn from(component: Component) -> Self {
+        match component {
+            Component::Android => InstallVariant::Android,
+            Component::Ios => InstallVariant::Ios,
+            Component::WebGl => InstallVariant::WebGl,
+            Component::Linux => InstallVariant::Linux,
+            Component::Windows => InstallVariant::Windows,
+            Component::WindowsMono => InstallVariant::WindowsMono,
+            _ => InstallVariant::Editor
         }
     }
 }

--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -45,16 +45,20 @@ pub fn ensure_tap_for_version_type(version_type: &VersionType) -> io::Result<()>
         VersionType::Beta => "wooga/unityversions-beta",
         VersionType::Patch => "wooga/unityversions-patch",
     };
+    debug!("ensure brew tap {}", tap);
     brew::tap::ensure(tap)
 }
 
 
 pub fn cask_name_for_type_version(variant: InstallVariant, version: &Version) -> brew::cask::Cask {
+    debug!("fetch cask name for variant {} and version {}", variant, version.to_string());
     let base_name = if variant == InstallVariant::Editor {
         String::from("unity")
     } else {
         format!("unity-{}-support-for-editor", variant)
     };
 
-    String::from(format!("{}@{}", base_name, version.to_string()))
+    let result = String::from(format!("{}@{}", base_name, version.to_string()));
+    debug!("{}", result);
+    result
 }

--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 
 pub mod installer;
 
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum InstallVariant {
     Android,
     Ios,

--- a/uvm_cli/src/lib.rs
+++ b/uvm_cli/src/lib.rs
@@ -42,6 +42,10 @@ pub enum ColorOption {
 }
 
 pub trait Options {
+    fn debug(&self) -> bool {
+        self.verbose()
+    }
+
     fn verbose(&self) -> bool {
         false
     }
@@ -82,8 +86,11 @@ fn set_loglevel<T>(options: &T)
 where
     T: Options,
 {
-    let log_spec_builder = if options.verbose() {
+    let log_spec_builder = if options.debug() {
         LogSpecification::default(LevelFilter::max())
+    }
+    else if options.verbose() {
+        LogSpecification::default(LevelFilter::Info)
     }
     else {
         LogSpecification::default(LevelFilter::Warn)

--- a/uvm_core/src/brew/cask.rs
+++ b/uvm_core/src/brew/cask.rs
@@ -50,6 +50,19 @@ pub fn install<I, S>(casks: I) -> io::Result<Child> where
         .spawn()
 }
 
+pub fn fetch<I, S>(casks: I, force:bool) -> io::Result<Child> where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>
+{
+    Command::new("brew")
+        .arg("cask")
+        .arg("fetch")
+        .args(casks)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+}
+
 pub fn uninstall<I, S>(casks: I) -> io::Result<Child> where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -1,6 +1,9 @@
 extern crate regex;
 extern crate serde;
 
+#[macro_use]
+extern crate log;
+
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -7,6 +7,7 @@ use self::Component::*;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
 pub enum Component {
+    Editor,
     Mono,
     VisualStudio,
     MonoDevelop,

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -37,6 +37,8 @@ impl Component {
             TvOs => Some("PlaybackEngines/AppleTVSupport"),
             Linux => Some("PlaybackEngines/LinuxStandaloneSupport"),
             Windows => Some("PlaybackEngines/WindowsStandaloneSupport"),
+            WindowsMono => Some("PlaybackEngines/WindowsStandaloneSupport"),
+            WebGl => Some("PlaybackEngines/WebGLSupport"),
             _ => None
         };
 

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -1,0 +1,93 @@
+use std::path::{PathBuf,Path};
+use std::str::FromStr;
+use std::fmt;
+use std::error::Error;
+use std::slice::Iter;
+use self::Component::*;
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+pub enum Component {
+    Mono,
+    VisualStudio,
+    MonoDevelop,
+    Documentation,
+    StandardAssets,
+    Android,
+    Ios,
+    TvOs,
+    WebGl,
+    Linux,
+    Windows,
+    WindowsMono,
+}
+
+impl Component {
+    pub fn iterator() -> Iter<'static, Component> {
+        static COMPONENTS: [Component;  12] = [Mono, VisualStudio, MonoDevelop, Documentation,
+        StandardAssets, Android, Ios, TvOs, WebGl, Linux, Windows, WindowsMono];
+        COMPONENTS.into_iter()
+    }
+
+    pub fn installpath(&self) -> Option<PathBuf> {
+        let path = match self {
+            StandardAssets => Some("Standard Assets"),
+            Android => Some("PlaybackEngines/AndroidPlayer"),
+            Ios => Some("PlaybackEngines/iOSSupport"),
+            TvOs => Some("PlaybackEngines/AppleTVSupport"),
+            Linux => Some("PlaybackEngines/LinuxStandaloneSupport"),
+            Windows => Some("PlaybackEngines/WindowsStandaloneSupport"),
+            _ => None
+        };
+
+        path.map(|p| Path::new(p).to_path_buf())
+    }
+
+    pub fn is_installed(&self, unity_install_location:&Path ) -> bool {
+        self.installpath()
+            .map(|install_path| unity_install_location.join(install_path))
+            .map(|install_path| install_path.exists())
+            .unwrap_or(false)
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseComponentError {
+    message: String
+}
+
+impl ParseComponentError {
+    fn new(message: &str) -> ParseComponentError {
+        ParseComponentError { message: String::from(message) }
+    }
+}
+
+impl fmt::Display for ParseComponentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ParseComponentError")
+    }
+}
+
+impl Error for ParseComponentError {
+    fn description(&self) -> &str {
+        &self.message[..]
+    }
+}
+
+impl FromStr for Component {
+    type Err = ParseComponentError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "standardassets" => Ok(Component::StandardAssets),
+            "mono" => Ok(Component::Mono),
+            "monodevelop" => Ok(Component::MonoDevelop),
+            "visualstudio" => Ok(Component::VisualStudio),
+            "ios" => Ok(Component::Ios),
+            "android" => Ok(Component::Android),
+            "webgl" => Ok(Component::WebGl),
+            "linux" => Ok(Component::Linux),
+            "windows" => Ok(Component::Windows),
+            x => Err(ParseComponentError::new(&format!("Unsupported component {}", x)))
+        }
+    }
+}

--- a/uvm_core/src/unity/installation.rs
+++ b/uvm_core/src/unity/installation.rs
@@ -3,6 +3,8 @@ use unity::Version;
 use std::cmp::Ordering;
 use std;
 use std::str::FromStr;
+use unity::Component;
+use unity::InstalledComponents;
 use std::io;
 use result;
 use UvmError;
@@ -54,6 +56,10 @@ impl Installation {
         } else {
             Err(UvmError::IoError(io::Error::new(io::ErrorKind::InvalidInput, "Provided Path is not a Unity installtion.")))
         }
+    }
+
+    pub fn installed_components(&self) -> InstalledComponents {
+        InstalledComponents::new(self.clone())
     }
 
     pub fn version(&self) -> &Version {

--- a/uvm_core/src/unity/version.rs
+++ b/uvm_core/src/unity/version.rs
@@ -20,7 +20,7 @@ impl PartialOrd for VersionType {
     }
 }
 
-#[derive(Eq,Debug,Clone)]
+#[derive(Eq,Debug,Clone,Hash)]
 pub struct Version {
     major: u32,
     minor: u32,


### PR DESCRIPTION
## Description
This patch implements a new command `install2` which can install the requested unity version to any location writable on the system.

It still uses `brew cask` to `fetch` the installer but will use the new installer routines added by #1.
The download and installation of the unity components is happening in parallel in multiple threads.

![uvm install2](https://user-images.githubusercontent.com/2523575/47096258-14db1c80-d22f-11e8-95e5-e73b970d8eac.png)

