### PR TITLE
Replace `spawn` method with `exec` in exec_command function

### DIFF
--- a/uvm_cli/src/lib.rs
+++ b/uvm_cli/src/lib.rs
@@ -32,6 +32,7 @@ use serde::de::Deserialize;
 use std::ffi::OsStr;
 use std::io;
 use std::process::Command;
+use std::os::unix::process::CommandExt;
 
 
 #[derive(PartialEq, Deserialize, Debug)]
@@ -109,16 +110,9 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    Command::new(command)
+    Err(Command::new(command)
         .args(args)
-        .spawn()?
-        .wait()
-        .and_then(|s| {
-            s.code().ok_or(io::Error::new(
-                io::ErrorKind::Interrupted,
-                "Process terminated by signal",
-            ))
-        })
+        .exec())
 }
 
 fn format_logs(writer: &mut io::Write, record: &Record) -> Result<(), io::Error> {


### PR DESCRIPTION
## Description

The function `pub fn exec_command<C, I, S>(command: C, args: I) -> io::Result<i32>` is used to call a child process (in most cases a sub command) and run it. As of now this meant that the mother process `uvm` was still executing. I replaces `spawn` with the system depending function `exec`. It is save to call `exec` here because both usecases of `exec_command` just gather resources to hand them over to the child process.

## Changes

![IMPROVE] sub command invocation by using `exec` instead of `spawn`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"