### PR TITLE
Refactor unity::Version and implement Serialize and Deserialize

### DIFF
--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -21,7 +21,6 @@ use uvm_core::brew;
 
 #[derive(Debug, Deserialize)]
 pub struct Options {
-    #[serde(with = "uvm_core::unity::unity_version_format")]
     arg_version: Version,
     flag_verbose: bool,
     flag_android: bool,

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -29,7 +29,6 @@ use uvm_core::install::InstallVariant;
 
 #[derive(Debug, Deserialize)]
 pub struct Options {
-    #[serde(with = "uvm_core::unity::unity_version_format")]
     arg_version: Version,
     arg_destination: Option<PathBuf>,
     flag_verbose: bool,

--- a/install/uvm-uninstall/src/lib.rs
+++ b/install/uvm-uninstall/src/lib.rs
@@ -19,7 +19,6 @@ use uvm_core::install::InstallVariant;
 
 #[derive(Debug, Deserialize)]
 pub struct UninstallOptions {
-    #[serde(with = "uvm_core::unity::unity_version_format")]
     arg_version: Version,
     flag_verbose: bool,
     flag_android: bool,

--- a/uvm_cli/src/use_version.rs
+++ b/uvm_cli/src/use_version.rs
@@ -4,7 +4,6 @@ use uvm_core;
 
 #[derive(Debug, Deserialize)]
 pub struct UseOptions {
-    #[serde(with = "uvm_core::unity::unity_version_format")]
     arg_version: Version,
     flag_verbose: bool,
     flag_color: ColorOption

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -8,7 +8,6 @@ pub use self::component::Component;
 pub use self::version::Version;
 pub use self::version::ParseVersionError;
 pub use self::version::VersionType;
-pub use self::version::unity_version_format;
 pub use self::current_installation::CurrentInstallation;
 pub use self::current_installation::current_installation;
 

--- a/uvm_core/src/unity/version.rs
+++ b/uvm_core/src/unity/version.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use std::result;
 use std::convert::From;
 use unity::Installation;
+use serde::{self, Serialize, Deserialize, Deserializer, Serializer};
 
 #[derive(PartialEq,Eq,Ord,Hash,Debug,Clone)]
 pub enum VersionType {
@@ -52,6 +53,24 @@ impl PartialEq for Version {
         && (self.minor == other.minor)
         && (self.patch == other.patch)
         && (self.revision == other.revision)
+    }
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let s = self.to_string();
+        serializer.serialize_str(&s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        let s = String::deserialize(deserializer)?;
+        Version::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -149,19 +168,6 @@ impl FromStr for Version {
 impl From<Installation> for Version {
     fn from(item: Installation) -> Self {
         item.version_owned()
-    }
-}
-
-pub mod unity_version_format {
-    use super::Version;
-    use std::str::FromStr;
-    use serde::{self, Deserialize, Deserializer};
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Version, D::Error>
-        where D: Deserializer<'de>
-    {
-        let s = String::deserialize(deserializer)?;
-        Version::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
## Description

The `unity::Version` struct wasn't properly serializeable with `serde`.
The module contained a special helper module `unity_version_format` that
was used with the helper macro from serde like this:

```rust
pub struct Options {
    #[serde(with = "uvm_core::unity::unity_version_format")]
    arg_version: Version,
    ...
}
```

This patch implements `serde::Serialize` and `serde::Deserialize` for
the `unity::Version` struct and makes it no longer nessary to use the
`with=` macro to serialize version values from `String`

## Changes

![IMPROVE] `unity::Version` serialization/deserialization.
![REMOVE] old helper module `uvm_core::unity::unity_version_format` and usages

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"