### PR TITLE
Refactor unity::Version

### DIFF
--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.5"
 plist = "0.3.0"
 dirs = { git = 'https://github.com/Larusso/dirs-rs.git' }
 itertools = "0.7.8"
+semver = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winver","memoryapi"] }

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate regex;
 extern crate serde;
 extern crate serde_json;
+extern crate semver;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
## Description

Use crate [semver] as the base version component instead of defining `major`, `minor` and `patch` on our own. This moves some of the version comparision down to the [semver] implementation.

This refactor also adds some helper methods to create versions.

* `a()` create a alpha version
* `b()` create a beta version
* `p()` create a patch version
* `f()` create a final version

and a `From<(u64,u64,u64,u64)>` implementation.

## Changes

![ADD] convient initializers
![ADD] tuple from implementation
![CHANGE] component type from `u32` to `u64`
![IMPROVE] version struct by using [semver]::Version as base componen

[semver]: https://crates.io/crates/semver

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
