### PR TITLE
Fix windows installer logic

### DIFF
--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -26,6 +26,7 @@ semver = "0.9.0"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winver","memoryapi"] }
 libc = "0.2.43"
+tempfile = "3"
 
 [dev-dependencies]
 proptest = "0.8.7"

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -11,7 +11,7 @@ extern crate log;
 extern crate proptest;
 #[cfg(test)]
 extern crate rand;
-#[cfg(test)]
+#[cfg(any(test,windows))]
 extern crate tempfile;
 extern crate plist;
 #[macro_use]


### PR DESCRIPTION
## Description

The windows unity installer accepts a commandline flag `/D` to set the destination for the installation. This flag must be provided in the form `/D=some\destination`. The rust `std::process::Command::spawn` method does some things to the provides arguments so that the installer skips over the flag. The result is that the installer uses the last selected destination and writes over the possible installation. This patch fixes this problem with a temp solution. I couldn't find a incantation from rust that worked so the patch logic introduces a tempary batch file with the correct installer incatation.

## Changes

![FIX] windows unity installer to destination

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"