### PR TITLE
Add custom install downloader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,6 @@ matrix:
     # - env: TARGET=thumbv7m-none-eabi
 
     # Testing other channels
-    - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
     - env: TARGET=x86_64-apple-darwin
       os: osx
       rust: nightly

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -12,3 +12,4 @@ serde = "1.0"
 serde_derive = "1.0"
 uvm_cli = { path = "../../uvm_cli" }
 uvm_core = { path = "../../uvm_core" }
+cluFlock = "0.1.5"

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -12,4 +12,3 @@ serde = "1.0"
 serde_derive = "1.0"
 uvm_cli = { path = "../../uvm_cli" }
 uvm_core = { path = "../../uvm_core" }
-cluFlock = "0.1.5"

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -3,12 +3,12 @@ extern crate serde_derive;
 extern crate console;
 extern crate serde;
 extern crate uvm_cli;
+#[macro_use]
 extern crate uvm_core;
 extern crate indicatif;
 
 #[macro_use]
 extern crate log;
-extern crate cluFlock;
 
 use console::style;
 use console::Term;
@@ -29,8 +29,8 @@ use uvm_core::install;
 use uvm_core::install::InstallVariant;
 use uvm_core::unity::hub;
 use uvm_core::unity::hub::editors::{EditorInstallation, Editors};
-use cluFlock::Flock;
 use uvm_core::unity::hub::paths;
+use uvm_core::utils;
 use std::fs;
 
 #[derive(Debug, Deserialize)]
@@ -220,20 +220,7 @@ impl UvmCommand {
 
         let lock_file_name = format!("{}.lock", &version);
         let lock_file = locks_dir.join(lock_file_name);
-        let lock_file = fs::File::create(lock_file)?;
-        let _lock = match lock_file.try_exclusive_lock() {
-            Ok(Some(lock)) => {
-                trace!("aquire lock for install operation");
-                Ok(lock)
-            },
-            Ok(None) => {
-                debug!("install already in progress.");
-                debug!("wait for other process to finish.");
-                let lock = lock_file.exclusive_lock()?;
-                Ok(lock)
-            },
-            Err(err) => Err(err)
-        }?;
+        lock_process!(lock_file);
 
         let mut editorInstallation:Option<EditorInstallation> = None;
         let base_dir = if let Some(ref destination) = options.destination() {

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -8,6 +8,7 @@ extern crate indicatif;
 
 #[macro_use]
 extern crate log;
+extern crate cluFlock;
 
 use console::style;
 use console::Term;
@@ -28,6 +29,9 @@ use uvm_core::install;
 use uvm_core::install::InstallVariant;
 use uvm_core::unity::hub;
 use uvm_core::unity::hub::editors::{EditorInstallation, Editors};
+use cluFlock::Flock;
+use uvm_core::unity::hub::paths;
+use std::fs;
 
 #[derive(Debug, Deserialize)]
 pub struct Options {
@@ -151,7 +155,7 @@ impl UvmCommand {
         .map_err(|error| {
             debug!("error loading installer: {}", style(&error).red());
             pb.finish_with_message(&format!("[{}] {}", &install_object.variant, style("error").red().bold()));
-            error
+            io::Error::new(io::ErrorKind::Other, format!("Failed to fetch installer url \n{}", error.to_string()))
         })?;
 
         debug!("installer location: {}", &installer.display());
@@ -209,8 +213,28 @@ impl UvmCommand {
     }
 
     pub fn exec(&self, options:Options) -> io::Result<()> {
-        self.stderr.write_line(&format!("{}: {}", style("install unity version").green(), options.version().to_string())).ok();
-        install::ensure_tap_for_version(&options.version())?;
+        let version = options.version();
+        self.stderr.write_line(&format!("{}: {}", style("install unity version").green(), version.to_string())).ok();
+        let locks_dir = paths::locks_dir().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Unable to locate locks directory."))?;
+        fs::DirBuilder::new().recursive(true).create(&locks_dir)?;
+
+        let lock_file_name = format!("{}.lock", &version);
+        let lock_file = locks_dir.join(lock_file_name);
+        let lock_file = fs::File::create(lock_file)?;
+        let _lock = match lock_file.try_exclusive_lock() {
+            Ok(Some(lock)) => {
+                trace!("aquire lock for install operation");
+                Ok(lock)
+            },
+            Ok(None) => {
+                debug!("install already in progress.");
+                debug!("wait for other process to finish.");
+                let lock = lock_file.exclusive_lock()?;
+                Ok(lock)
+            },
+            Err(err) => Err(err)
+        }?;
+
         let mut editorInstallation:Option<EditorInstallation> = None;
         let base_dir = if let Some(ref destination) = options.destination() {
             if destination.exists() && !destination.is_dir() {

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -25,7 +25,11 @@ dirs = { git = 'https://github.com/Larusso/dirs-rs.git' }
 itertools = "0.7.8"
 semver = "0.9.0"
 reqwest = "0.9.4"
-
+tempfile = "3"
+md-5 = { version = "0.8.0", features = ["std"] }
+hex-serde = "0.1.0"
+[target.'cfg(unix)'.dependencies]
+cluFlock = "0.1.5"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winver","memoryapi"] }
 libc = "0.2.43"
@@ -34,4 +38,3 @@ tempfile = "3"
 [dev-dependencies]
 proptest = "0.8.7"
 rand = "0.5"
-tempfile = "3"

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -24,6 +24,24 @@ extern crate dirs;
 #[macro_use]
 extern crate itertools;
 
+pub mod utils;
+
+#[macro_export]
+#[cfg(unix)]
+macro_rules! lock_process {
+
+    ($lock_path:expr) => (
+        let lock_file = fs::File::create($lock_path)?;
+        let _lock = utils::lock_process_or_wait(&lock_file)?;
+    )
+}
+
+#[macro_export]
+#[cfg(windows)]
+macro_rules! lock_process {
+    ($lock_path:expr) => ()
+}
+
 #[macro_export]
 macro_rules! cargo_version {
     // `()` indicates that the macro takes no argument.

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -5,7 +5,9 @@ extern crate serde_yaml;
 extern crate serde_ini;
 extern crate semver;
 extern crate reqwest;
-
+extern crate md5;
+#[cfg(unix)]
+extern crate cluFlock;
 #[macro_use]
 extern crate log;
 
@@ -14,7 +16,6 @@ extern crate log;
 extern crate proptest;
 #[cfg(test)]
 extern crate rand;
-#[cfg(any(test,windows))]
 extern crate tempfile;
 extern crate plist;
 #[macro_use]

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -18,6 +18,7 @@ pub enum Component {
     #[serde(rename = "iOS")]
     Ios,
     TvOs,
+    #[serde(rename = "WebGL")]
     WebGl,
     Linux,
     Windows,

--- a/uvm_core/src/unity/hub/paths.rs
+++ b/uvm_core/src/unity/hub/paths.rs
@@ -36,7 +36,11 @@ pub fn default_editor_config_path() -> Option<PathBuf> {
 }
 
 pub fn cache_dir() -> Option<PathBuf> {
-    dirs::cache_dir().map(|path| path.join("Wooga").join("Unity Version Manager"))
+    dirs::cache_dir().map(|path| path.join("Wooga").join("UnityVersionManager"))
+}
+
+pub fn locks_dir() -> Option<PathBuf> {
+    cache_dir().map(|path| path.join("locks"))
 }
 
 #[cfg(test)]
@@ -52,5 +56,6 @@ mod tests {
         println!("install_path:                        {:?}", install_path());
         println!("default_install_path:                {:?}", default_install_path());
         println!("cache_dir:                           {:?}", cache_dir());
+        println!("locks:                               {:?}", locks_dir());
     }
 }

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -8,6 +8,8 @@ pub mod urls;
 pub use self::installation::Installation;
 pub use self::component::Component;
 pub use self::version::Version;
+pub use self::version::manifest::Manifest;
+pub use self::version::manifest::MD5;
 pub use self::version::ParseVersionError;
 pub use self::version::VersionType;
 pub use self::current_installation::CurrentInstallation;

--- a/uvm_core/src/unity/version/manifest/mod.rs
+++ b/uvm_core/src/unity/version/manifest/mod.rs
@@ -83,14 +83,18 @@ impl Manifest {
 
 #[derive(Deserialize, Debug)]
 pub struct ComponentData {
-    title: String,
-    description: String,
+    pub title: String,
+    pub description: String,
     url: String,
-    size: u64,
-    md5: Option<String>,
+    pub size: u64,
+    pub md5: Option<MD5>,
     #[serde(flatten)]
-    other: HashMap<String, String>,
+    pub other: HashMap<String, String>,
 }
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Deserialize)]
+#[serde(transparent)]
+pub struct MD5(#[serde(with="hex_serde")]pub [u8; 16]);
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 #[cfg(test)]

--- a/uvm_core/src/unity/version/mod.rs
+++ b/uvm_core/src/unity/version/mod.rs
@@ -10,7 +10,7 @@ use serde::{self, Serialize, Deserialize, Deserializer, Serializer};
 use semver;
 
 mod hash;
-mod manifest;
+pub mod manifest;
 
 #[cfg(target_os = "windows")]                                           mod win;
 #[cfg(target_os = "macos")]                                             mod mac;

--- a/uvm_core/src/utils.rs
+++ b/uvm_core/src/utils.rs
@@ -1,0 +1,26 @@
+#[cfg(unix)]
+use cluFlock::{Flock, ExclusiveSliceLock};
+use std::io;
+use std::fs::File;
+
+#[cfg(unix)]
+pub fn lock_process_or_wait<'a>(lock_file:&'a File) -> io::Result<ExclusiveSliceLock<'a>> {
+    match lock_file.try_exclusive_lock() {
+        Ok(Some(lock)) => {
+            trace!("aquired process lock.");
+            Ok(lock)
+        },
+        Ok(None) => {
+            debug!("progress lock already aquired.");
+            debug!("wait for other process to finish.");
+            let lock = lock_file.exclusive_lock()?;
+            Ok(lock)
+        },
+        Err(err) => Err(err)
+    }
+}
+
+#[cfg(windows)]
+pub fn lock_process_or_wait(lock_file:File) -> io::Result<()> {
+    Ok(())
+}

--- a/uvm_core/tests/download_unity_installer.rs
+++ b/uvm_core/tests/download_unity_installer.rs
@@ -1,0 +1,12 @@
+extern crate uvm_core;
+use uvm_core::install;
+use uvm_core::unity;
+
+#[test]
+fn downloads_editor_installer_for_version() {
+    let variant = install::InstallVariant::Editor;
+    let version = unity::Version::f(2018,2,6,1);
+
+    let installer_path = install::download_installer(variant, &version).expect("path to installer");
+    assert!(installer_path.exists());
+}


### PR DESCRIPTION
## Description

The first implementation used `brew cask` to download the unity module installers. This implementation doesn't work on windows or linux so this patch adds a first implementation for a custom download logic. The installer locations are fetched from the version manifest and downloaded to a `cache` directory:

* macos: `~/Library/Caches/Wooga/UnityVersionManager/installers`
* windows : `%HOME%/AppData/Local/UnityVersionManager/installers`

The download process is restartable if the tool fails or any other interrupt happens. The install command and the download function will create a lock file to lock the temporary installation file so that only one uvm process can access it at the same time.

All installer binaries are verified with the provided `md5` checksum from the unity version manifest.

This implementation acts as a base and needs heavy refactoring.

## Changes

![ADD] unity installer download implementation
![ADD] process locking
![ADD] checksum verification for downloaded installer binaries

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"