### PR TITLE
Move some cli base traits/function to custom crate

### DIFF
--- a/uvm_cli/Cargo.toml
+++ b/uvm_cli/Cargo.toml
@@ -11,3 +11,4 @@ serde = "1.0"
 serde_derive = "1.0"
 uvm_core = { path = "../uvm_core" }
 console = "0.6.1"
+cli_core = "0.1.0"

--- a/uvm_cli/src/lib.rs
+++ b/uvm_cli/src/lib.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate docopt;
 extern crate serde;
-#[macro_use]
 extern crate uvm_core;
+extern crate cli_core;
 extern crate console;
 #[macro_use]
 extern crate log;
@@ -25,81 +24,14 @@ pub use self::utils::print_error_and_exit;
 pub use self::utils::sub_command_path;
 pub use self::uvm::*;
 
-use console::Style;
-use docopt::Docopt;
-use flexi_logger::{Level, LevelFilter, LogSpecification, Logger, Record};
-use serde::de::Deserialize;
 use std::ffi::OsStr;
 use std::io;
 use std::process::Command;
 
+pub use cli_core::{get_options, ColorOption, Options};
+
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
-
-#[derive(PartialEq, Deserialize, Debug)]
-pub enum ColorOption {
-    Auto,
-    Always,
-    Never,
-}
-
-pub trait Options {
-    fn debug(&self) -> bool {
-        self.verbose()
-    }
-
-    fn verbose(&self) -> bool {
-        false
-    }
-
-    fn color(&self) -> &ColorOption {
-        &ColorOption::Auto
-    }
-}
-
-pub fn get_options<'a, T>(usage: &str) -> io::Result<T>
-where
-    T: Deserialize<'a> + Options,
-{
-    Docopt::new(usage)
-        .and_then(|d| Ok(d.version(Some(cargo_version!()))))
-        .and_then(|d| Ok(d.options_first(true)))
-        .and_then(|d| d.deserialize())
-        .map_err(|e| e.exit())
-        .and_then(|o| {
-            set_colors_enabled(&o);
-            set_loglevel(&o);
-            Ok(o)
-        })
-}
-
-fn set_colors_enabled<T>(options: &T)
-where
-    T: Options,
-{
-    match *options.color() {
-        ColorOption::Never => console::set_colors_enabled(false),
-        ColorOption::Always => console::set_colors_enabled(true),
-        ColorOption::Auto => (),
-    };
-}
-
-fn set_loglevel<T>(options: &T)
-where
-    T: Options,
-{
-    let log_spec_builder = if options.debug() {
-        LogSpecification::default(LevelFilter::max())
-    } else if options.verbose() {
-        LogSpecification::default(LevelFilter::Info)
-    } else {
-        LogSpecification::default(LevelFilter::Warn)
-    };
-
-    let log_spec = log_spec_builder.build();
-
-    Logger::with(log_spec).format(format_logs).start().unwrap();
-}
 
 #[cfg(unix)]
 pub fn exec_command<C, I, S>(command: C, args: I) -> io::Result<i32>
@@ -128,18 +60,4 @@ where
                 "Process terminated by signal",
             ))
         })
-}
-
-fn format_logs(writer: &mut io::Write, record: &Record) -> Result<(), io::Error> {
-    let style = match record.level() {
-        Level::Trace => Style::new().white().dim().italic(),
-        Level::Debug => Style::new().white().dim(),
-        Level::Info => Style::new().white(),
-        Level::Warn => Style::new().yellow(),
-        Level::Error => Style::new().red(),
-    };
-
-    writer
-        .write(&format!("{}", style.apply_to(record.args())).into_bytes())
-        .map(|_| ())
 }


### PR DESCRIPTION
## Description

The underlying cli options trait has been moved to a new crate [cli_core]. This crate is also used for another `uvm` related project and doesn't need the `uvm_core` dependencies.

## Changes

![ADD] ![NEW] dependency [cli_core]
![IMPROVE] `uvm_cli` source setup. Reexport removed methods from [cli_core]

[cli_core]: https://crates.io/crates/cli_core

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"