### PR TITLE
Use Deref trait for Url tuple structs

### DIFF
--- a/uvm_core/src/unity/urls.rs
+++ b/uvm_core/src/unity/urls.rs
@@ -1,12 +1,29 @@
+use std::ops::Deref;
+use std::convert::Into;
 use reqwest::Url;
 use result::Result;
 use unity::version::{Version, VersionType};
 
-const BASE_URL: &'static str = "https://download.unity3d.com/download_unity/";
-const BETA_BASE_URL: &'static str = "https://beta.unity3d.com/download/";
+const BASE_URL: &str = "https://download.unity3d.com/download_unity/";
+const BETA_BASE_URL: &str = "https://beta.unity3d.com/download/";
 
 #[derive(Debug)]
 pub struct DownloadURL(Url);
+
+impl Deref for DownloadURL {
+    type Target = Url;
+
+    fn deref(&self) -> &Url {
+        &self.0
+    }
+}
+
+impl Into<Url> for DownloadURL {
+    fn into(self) -> Url {
+        self.into_url()
+    }
+}
+
 impl DownloadURL {
     pub fn new<V: AsRef<Version>>(version: V) -> Result<DownloadURL> {
         let version = version.as_ref();
@@ -25,17 +42,27 @@ impl DownloadURL {
         Ok(DownloadURL(url))
     }
 
-    pub fn to_url(self) -> Url {
+    pub fn into_url(self) -> Url {
         self.0
-    }
-
-    pub fn join(&self, input: &str) -> Result<Url> {
-        self.0.join(input).map_err(|err| err.into())
     }
 }
 
 #[derive(Debug)]
 pub struct IniUrl(Url);
+
+impl Deref for IniUrl {
+    type Target = Url;
+
+    fn deref(&self) -> &Url {
+        &self.0
+    }
+}
+
+impl Into<Url> for IniUrl {
+    fn into(self) -> Url {
+        self.into_url()
+    }
+}
 
 impl IniUrl {
     #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -58,7 +85,7 @@ impl IniUrl {
         unimplemented!()
     }
 
-    pub fn to_url(self) -> Url {
+    pub fn into_url(self) -> Url {
         self.0
     }
 }

--- a/uvm_core/src/unity/version/manifest/mod.rs
+++ b/uvm_core/src/unity/version/manifest/mod.rs
@@ -60,7 +60,7 @@ impl Manifest {
         P: AsRef<Path>,
     {
         let ini_url = IniUrl::new(version)?;
-        let url = ini_url.to_url();
+        let url = ini_url.into_url();
         let body = reqwest::get(url)
             .and_then(|mut response| response.text())
             .map(Self::cleanup_ini_data)?;


### PR DESCRIPTION
## Description

This patch is a small cleanup to use the `Deref` trait instead of defining delegate functions for the `Url` wrapper structs `DownloadURL` and `IniUrl`. These structs also implement the `Into<Url>` trait to convert them into Url objects.

## Changes

![IMPROVE] tuple struct usage with Deref and Into traits

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"