### PR TITLE
Add optional pattern argument to versions command

### DIFF
--- a/install/uvm-versions/src/main.rs
+++ b/install/uvm-versions/src/main.rs
@@ -7,8 +7,11 @@ const USAGE: &str = "
 uvm-versions - List available Unity versions to install.
 
 Usage:
-  uvm-versions [options]
+  uvm-versions [options] [<pattern>]
   uvm-versions (-h | --help)
+
+Arguments:
+  pattern           a regex pattern to filter the result
 
 Options:
   -a, --all         list all available versions for the selected version types


### PR DESCRIPTION
## Description

To list only versions of interest, the `versions` command now understands an optional argument `pattern`. The pattern is a regex string and will be matched on the result list
after filtering the release types etc.

## Examples

_all versions containing `1`_
```
$uvm versions 1
Latest versions to install matching the pattern `1`:
2018.2.14f1
2018.3.0b8
5.6.4p1
5.6.4f1
2019.1.0a7
2017.3.1p4
2017.4.14f1
2017.3.0b11
```

_all versions starting with `2`_
```
$uvm versions ^2
Latest versions to install matching the pattern `^2`:
2017.4.14f1
2017.3.0b11
2017.3.1p4
2018.3.0b8
2018.2.14f1
2019.1.0a7
```

_all versions starting with `2` and end with `4`_
```
$uvm versions '^2.*4$'
Latest versions to install matching the pattern `^2.*4$`:
2017.3.1p4
```

_all versions starting with `2017` or `2019`_
```
$uvm versions '^20(17|19)'
Latest versions to install matching the pattern `^20(17|19)`:
2017.4.14f1
2017.3.0b11
2017.3.1p4
2019.1.0a7
```

## Changes

![ADD] ![NEW] optional argument `pattern` to _versions_ command

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"