### PR TITLE
Use unity-versions-service for version lookup

### DIFF
--- a/uvm_core/src/unity/hub/paths.rs
+++ b/uvm_core/src/unity/hub/paths.rs
@@ -44,6 +44,10 @@ pub fn locks_dir() -> Option<PathBuf> {
     cache_dir().map(|path| path.join("locks"))
 }
 
+pub fn hash_cache_dir() -> Option<PathBuf> {
+    cache_dir().map(|path| path.join("versions"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/uvm_core/src/unity/urls.rs
+++ b/uvm_core/src/unity/urls.rs
@@ -26,13 +26,16 @@ impl Into<Url> for DownloadURL {
 
 impl DownloadURL {
     pub fn new<V: AsRef<Version>>(version: V) -> Result<DownloadURL> {
+        use std::error::Error;
+
         let version = version.as_ref();
         let mut url = match version.release_type() {
             VersionType::Final => Url::parse(BASE_URL),
             _ => Url::parse(BETA_BASE_URL),
         }?;
 
-        let hash = version.version_hash().ok_or_else(|| {
+        let hash = version.version_hash().map_err(|err| {
+            warn!("{}", err.description());
             crate::error::IllegalOperationError::new(&format!(
                 "No hash value for version: {} available",
                 version

--- a/uvm_core/src/unity/version/mod.rs
+++ b/uvm_core/src/unity/version/mod.rs
@@ -141,8 +141,8 @@ impl Version {
         &self.release_type
     }
 
-    pub fn version_hash(&self) -> Option<String> {
-        hash::hash_for_version(self).ok()
+    pub fn version_hash(&self) -> std::io::Result<String> {
+        hash::hash_for_version(self)
     }
 
     pub fn major(&self) -> u64 {
@@ -399,13 +399,13 @@ mod tests {
     #[test]
     fn fetch_hash_for_known_version() {
         let version = Version::f(2017, 1, 0, 2);
-        assert_eq!(version.version_hash(), Some(String::from("66e9e4bfc850")));
+        assert_eq!(version.version_hash().unwrap(), String::from("66e9e4bfc850"));
     }
 
     #[test]
     fn fetch_hash_for_unknown_version_yields_none() {
         let version = Version::f(2080, 2, 0, 2);
-        assert_eq!(version.version_hash(), None);
+        assert!(version.version_hash().is_err());
     }
 
     proptest! {


### PR DESCRIPTION
## Description

Instead of using a static list of released versions, we should use a remote service to fetch a recent list of released unity versions. This patch adds a remote call to the [unity-versions-service] to fetch a complete list of all available versions to install and to fetch the revision hash for a given version to create the manifest url.

### all versions

The function `uvm_core::unity::version::hash::all_versions` used to create an iterator from a `HashMap` created at runtime from a static yml string. This `HashMap` is still in place for now for the revision hash fetch but no longer used for the list of all available versions. The new implementation will call a remove service [unity-versions-service] with the endpoint `/versions` to retrieve an up-to-date list of all versions. There is no local cache or service config in this patch. Every time the `uvm_core::unity::version::hash::all_versions` function is called, the remote server will be called as well. Future patches will change this.

### version hashes

The function `uvm_core::unity::version::hash::hash_for_version` used to fetch the revision hash for the given version from a semi static `HashMap` (see _all versions_). This patch adds two fallback functions that gets triggered if the given version is not included in `HashMap`.

1. the hash will be fetched from a local cache file
2. the [unity-versions-service] will be called at the endpoint `/versions/${VERSION}/hash`

If the hash was fetched from the remote service it will be saved in a local cache file to limit network calls in the future.

## Changes

* ![IMPROVE] use [unity-versions-service] to fetch list of available versions
* ![IMPROVE] use [unity-versions-service] as a fallback to retrieve revision hash for a given versions

resolves #32 

[unity-versions-service]: https://github.com/Larusso/unity-versions-service

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"