### PR TITLE
Cleanup versions command

### DIFF
--- a/install/uvm-versions/Cargo.toml
+++ b/install/uvm-versions/Cargo.toml
@@ -8,6 +8,7 @@ console = "0.6.1"
 regex = "0.2"
 itertools = "0.7.8"
 serde = "1.0"
+log = "0.4.5"
 serde_derive = "1.0"
 indicatif = "0.9.0"
 uvm_cli = { path = "../../uvm_cli" }

--- a/install/uvm-versions/src/main.rs
+++ b/install/uvm-versions/src/main.rs
@@ -1,6 +1,11 @@
 extern crate uvm_cli;
 extern crate uvm_versions;
+#[macro_use]
+extern crate log;
+extern crate console;
 
+use console::style;
+use std::process;
 use uvm_versions::VersionsOptions;
 
 const USAGE: &str = "
@@ -20,11 +25,20 @@ Options:
   --alpha           list alpha versions
   -p, --patch       list patch versions
   -v, --verbose     print more output
+  -d, --debug       print debug output
   --color WHEN      Coloring: auto, always, never [default: auto]
   -h, --help        show this help message and exit
 ";
 
 fn main() -> std::io::Result<()> {
     let options: VersionsOptions = uvm_cli::get_options(USAGE)?;
-    uvm_versions::UvmCommand::new().exec(&options)
+    uvm_versions::UvmCommand::new()
+        .exec(&options)
+        .unwrap_or_else(|err| {
+            let message = "Failure listing available versions";
+            eprintln!("{}", style(message).red());
+            info!("{}", &format!("{}", style(err).red()));
+            process::exit(1);
+        });
+    Ok(())
 }

--- a/uvm_core/src/unity/version/mod.rs
+++ b/uvm_core/src/unity/version/mod.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use semver;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
-use std::convert::{AsRef, From};
+use std::convert::{AsMut, AsRef, From};
 use std::error::Error;
 use std::fmt;
 use std::result;
@@ -203,6 +203,12 @@ impl fmt::Display for Version {
 
 impl AsRef<Version> for Version {
     fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl AsMut<Version> for Version {
+    fn as_mut(&mut self) -> &mut Self {
         self
     }
 }


### PR DESCRIPTION
## Description

The whole version filter logic in the `uvm versions` command is quite complicated and a long mess. This patch tries to add more readability by splitting the logic into multiple functions. Instead of long type names for nested `HashMap`s this patch adds some internal type aliases. This keeps the function definitions shorter and adds more clarity.

This won't be the last time this command is refactored because
readability is only partially created with these changes.

## Changes

![IMPROVE] filter logic in `uvm versions` command
![ADD] `AsMut` trait implementation for `Version`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"