### PR TITLE
Fix windows installation logic

### DIFF
--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -335,7 +335,12 @@ impl UvmCommand {
             if let Some(variants) = options.install_variants() {
                 for variant in variants {
                     let component: Component = variant.into();
-                    let variant_destination = component.installpath();
+                    //fix better
+                    let variant_destination = if cfg![windows] {
+                        Some(base_dir.to_path_buf())
+                    } else {
+                        component.installpath()
+                    };
                     let installation_data = InstallObject {
                         version: options.version().to_owned(),
                         variant: component.into(),

--- a/uvm_core/src/install/installer/windows.rs
+++ b/uvm_core/src/install/installer/windows.rs
@@ -33,7 +33,7 @@ fn install_from_exe(installer: &PathBuf, destination: &PathBuf) -> io::Result<()
     {
         let script = install_helper.as_file_mut();
         let install_command = format!(
-            r#"CALL "{}" /S /D="{}""#,
+            r#"CALL "{}" /S /D={}"#,
             installer.display(),
             destination.display()
         );

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -66,19 +66,7 @@ impl Component {
 
     #[cfg(target_os = "windows")]
     pub fn installpath(self) -> Option<PathBuf> {
-        let path = match self {
-            StandardAssets => Some(r"Editor"),
-            Android => Some(r"Editor"),
-            Ios => Some(r"Editor"),
-            TvOs => Some(r"Editor"),
-            Linux => Some(r"Editor"),
-            Windows => Some(r"Editor"),
-            WindowsMono => Some(r"Editor"),
-            WebGl => Some(r"Editor"),
-            _ => None,
-        };
-
-        path.map(|p| Path::new(p).to_path_buf())
+        None
     }
 
     #[cfg(target_os = "macos")]
@@ -94,8 +82,8 @@ impl Component {
             Ios => Some(r"Editor\Data\PlaybackEngines\iOSSupport"),
             TvOs => Some(r"Editor\Data\PlaybackEngines\AppleTVSupport"),
             Linux => Some(r"Editor\Data\PlaybackEngines\LinuxStandaloneSupport"),
-            Windows => Some(r"Editor\Data\PlaybackEngines\windowsstandalonesupport"),
-            WindowsMono => Some(r"Editor\Data\PlaybackEngines\windowsstandalonesupport"),
+            //Windows => Some(r"Editor\Data\PlaybackEngines\windowsstandalonesupport"),
+            //WindowsMono => Some(r"Editor\Data\PlaybackEngines\windowsstandalonesupport"),
             WebGl => Some(r"Editor\Data\PlaybackEngines\WebGLSupport"),
             _ => None,
         };


### PR DESCRIPTION
## Description

### Fix install logic

The windows install logic was still broken due to some path errors
introduced in a earlier commit. It was possible to install versions, but
the installer didn't use the passed destination value and either
installed to the default destination or to the last destination used.
Both editor and component installer behave that way.

### Remove preinstalled components from component list

On windows the __windows__ component is preinstalled. That is the same
on mac os where the macos component is installed with the editor. The
function `installed_components` will no longer report the __windows__ or
__windows-mono__ component on windows.

### Fix install location for components

The install location `Editor` is not working. The installer claims not
to find the __Unity.exe__ in the specified directory. Which is strange
since it resides in the `Editor` directory of the installation. The
component installer wants to have the root installation directory which
only contains the `Editor` directory (it seems that unity itself is not
100% sure what the programm root actually is)

## Changes

* ![FIX] windows install logic
* ![FIX] windows component list
* ![FIX] windows install location for components

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"