### PR TITLE
Add download progress handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "console 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +823,14 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1693,7 +1713,7 @@ version = "2.1.0"
 dependencies = [
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flexi_logger 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1969,6 +1989,7 @@ dependencies = [
 "checksum hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cd73f14ad370d3b4d4b7dce08f69b81536c82e39fcc89731930fe5788cd661"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c60da1c9abea75996b70a931bba6c750730399005b61ccd853cee50ef3d0d0c"
 "checksum indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
@@ -1996,6 +2017,7 @@ dependencies = [
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
+"checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
 "checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"

--- a/install/uvm-install/Cargo.toml
+++ b/install/uvm-install/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 
 [dependencies]
 flexi_logger = "0.9.2"
-indicatif = "0.9.0"
+indicatif = "0.11.0"
 log = "0.4.5"
 console = "0.6.1"
 serde = "1.0"

--- a/install/uvm-install/src/progress.rs
+++ b/install/uvm-install/src/progress.rs
@@ -1,0 +1,57 @@
+use indicatif;
+use std::ops::Deref;
+use uvm_core::progress::ProgressHandler;
+
+pub struct ProgressBar(indicatif::ProgressBar);
+pub struct MultiProgress(indicatif::MultiProgress);
+
+impl ProgressBar {
+    pub fn new(len: u64) -> ProgressBar {
+        ProgressBar(indicatif::ProgressBar::new(len))
+    }
+}
+
+impl MultiProgress {
+    pub fn new() -> MultiProgress {
+        MultiProgress(indicatif::MultiProgress::new())
+    }
+
+    pub fn add(&self, pb:indicatif::ProgressBar) -> ProgressBar {
+        ProgressBar(self.0.add(pb))
+    }
+}
+
+impl Deref for ProgressBar {
+    type Target = indicatif::ProgressBar;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Deref for MultiProgress {
+    type Target = indicatif::MultiProgress;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ProgressHandler for ProgressBar {
+    fn inc(&self, delta: u64) {
+        self.0.inc(delta)
+    }
+
+    fn set_length(&self, len: u64) {
+        self.0.set_length(len);
+        self.0.set_draw_delta(len/100);
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.0.set_position(pos)
+    }
+
+    fn finish(&self) {
+        self.0.finish()
+    }
+}

--- a/uvm_core/src/install/mod.rs
+++ b/uvm_core/src/install/mod.rs
@@ -14,6 +14,6 @@ pub use self::installer::install_module;
 pub use self::variant::InstallVariant;
 
 pub fn download_installer(variant: InstallVariant, version: &Version) -> Result<PathBuf> {
-    let d = Loader::new(variant, version.to_owned());
+    let mut d = Loader::new(variant, version.to_owned());
     d.download()
 }

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -28,6 +28,7 @@ extern crate itertools;
 extern crate error_chain;
 
 pub mod utils;
+pub mod progress;
 
 #[macro_export]
 #[cfg(unix)]

--- a/uvm_core/src/progress.rs
+++ b/uvm_core/src/progress.rs
@@ -1,0 +1,7 @@
+
+pub trait ProgressHandler {
+    fn finish(&self);
+    fn inc(&self, delta: u64);
+    fn set_length(&self, len: u64);
+    fn set_position(&self, pos: u64);
+}

--- a/uvm_core/src/unity/version/manifest/mod.rs
+++ b/uvm_core/src/unity/version/manifest/mod.rs
@@ -31,6 +31,18 @@ impl Manifest {
             .and_then(|c| self.base_url.join(&c.url).ok())
     }
 
+    pub fn size(&self, component: Component) -> Option<u64> {
+        self.components
+            .get(&component)
+            .map(|c| {
+                if cfg![windows] {
+                    c.size * 1024
+                } else {
+                    c.size
+                }
+            })
+    }
+
     fn get_manifest(version: Version) -> Result<Manifest> {
         let cache_dir = paths::cache_dir().ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "Unable to fetch cache directory")


### PR DESCRIPTION
## Description

The progress handler only showed general progress of the install states:

- download installer
- waiting
- installing
- done

This patch adds an optional progress handler trait to the installer
downloader. With this handler, it is possible to receive the progress of
the download and display it.

```
1/6 [editor]         ⠁ download installer  [===================>--------]  78%
2/6 [linux]          ⠁ download installer  [======>---------------------]  10%
3/6 [windows]        ⠁ download installer  [>---------------------------]   1%
4/6 [android]        ⠁ download installer  [==============>-------------]  50%
5/6 [ios]            ⠁ download installer  [----------------------------]   0%
6/6 [webgl]          ⠁ waiting
```

## Changes

![IMPROVE] download progress handling

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"