### PR TITLE
Linux Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ sudo: required
 env:
   global:
     - CRATE_NAME=uvm
-    - RUST_LOG='reqwest=debug'
 
 matrix:
   # TODO These are all the build jobs. Adjust as necessary. Comment out what you
@@ -37,7 +36,7 @@ matrix:
     # - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
     #   os: osx
     #
-    # # Linux
+    # Linux
     # - env: TARGET=aarch64-unknown-linux-gnu
     # - env: TARGET=arm-unknown-linux-gnueabi
     # - env: TARGET=armv7-unknown-linux-gnueabihf
@@ -51,7 +50,7 @@ matrix:
     # - env: TARGET=powerpc64-unknown-linux-gnu
     # - env: TARGET=powerpc64le-unknown-linux-gnu
     # - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-gnu
     # - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
@@ -119,12 +118,6 @@ cache:
 before_cache:
   # Travis can't cache files that are not readable by "others"
   - travis_wait chmod -R a+r $HOME/.cargo
-
-branches:
-  only:
-    # release tags
-    - /^v\d+\.\d+\.\d+.*$/
-    - master
 
 notifications:
   email:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,11 +55,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -67,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,6 +159,24 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -424,7 +441,7 @@ name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -433,7 +450,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -508,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -516,7 +533,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -541,7 +558,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -580,7 +597,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -604,7 +621,7 @@ version = "0.12.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,7 +650,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -842,6 +859,15 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "msdos_time"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1059,6 +1085,11 @@ dependencies = [
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "podio"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -1321,7 +1352,7 @@ dependencies = [
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1607,7 +1638,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1627,7 +1658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1635,7 +1666,7 @@ name = "tokio-current-thread"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1645,7 +1676,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1654,7 +1685,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1664,7 +1695,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1682,7 +1713,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1691,7 +1722,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1706,7 +1737,7 @@ dependencies = [
  "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1720,7 +1751,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1732,6 +1763,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "transformation-pipeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "try-lock"
@@ -1797,6 +1833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unzip"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transformation-pipeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"
@@ -2005,6 +2051,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unzip 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2036,7 +2083,7 @@ name = "want"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2095,6 +2142,18 @@ dependencies = [
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zip"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
@@ -2103,8 +2162,8 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f77aa27f55a4beb477ff6bc4d9bf72f90eb422b19c1d8e5a644b8aeb674d66"
-"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
+"checksum backtrace-sys 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "12cb9f1eef1d1fc869ad5a26c9fa48516339a15e54a227a25460fc304815fdb3"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
@@ -2117,6 +2176,8 @@ dependencies = [
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
+"checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
@@ -2156,7 +2217,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
+"checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
@@ -2194,6 +2255,7 @@ dependencies = [
 "checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -2218,6 +2280,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7316832d9ac5da02786bdc89a3faf0ca07070212b388766e969078fd593edc"
+"checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "926d0604475349f463fe44130aae73f2294b5309ab2ca0310b998bd334ef191f"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
@@ -2289,6 +2352,7 @@ dependencies = [
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
+"checksum transformation-pipeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce1d17c634c5196b37a2680f31627ab35b9e84e5f7f1abd13731c3fbd71dea36"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
@@ -2299,6 +2363,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unzip 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90e59a2baae95b4b60ecd5a1ba39e9654b09b09bf813989c70f52c957c213dfd"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
@@ -2315,3 +2380,4 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+"checksum zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e7341988e4535c60882d5e5f0b7ad0a9a56b080ade8bdb5527cb512f7b2180e0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+[target.x86_64-unknown-linux-gnu]
+image = "tslarusso/uvm_x86_64-unknown-linux-gnu:v0.1.4"
+
+[build.env]
+passthrough = [
+  "RUST_BACKTRACE",
+  "RUST_LOG",
+]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This tool allows to install and manage multiple unity versions on a system from 
 [![Latest Release](https://img.shields.io/github/release/Larusso/unity-version-manager.svg)](https://github.com/Larusso/unity-version-manager/releases/latest)
 ![macOS-supported](https://img.shields.io/badge/macOS-supported-brightgreen.svg)
 ![windows-experimental](https://img.shields.io/badge/windows-experimental-blue.svg)
-![linux-unsupported](https://img.shields.io/badge/linux-unsupported-red.svg)
+![linux-experimental](https://img.shields.io/badge/linux-experimental-blue.svg)
 
 
 Installation

--- a/ci/custom_images/x86_64-unknown-linux-gnu.Dockerfile
+++ b/ci/custom_images/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,0 +1,16 @@
+FROM japaric/x86_64-unknown-linux-gnu:v0.1.4
+
+RUN mkdir -p /home/ci/.cache
+RUN mkdir -p /home/ci/.config
+RUN mkdir -p /home/ci/.local/share
+
+# Set the home directory to our app user's home.
+ENV HOME=/home/ci
+ENV RUST_BACKTRACE=1
+ENV RUST_LOG='warning, uvm_core=trace'
+
+RUN apt-get update && \
+    apt-get install -y build-essential libssl-dev pkg-config openssl p7zip-full cpio
+
+# Chown all the files to the app user.
+RUN chmod -R 777 $HOME

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -247,7 +247,7 @@ impl UvmCommand {
         }
 
         let destination = install_object.clone().destination.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "Missing installtion destination")
+            io::Error::new(io::ErrorKind::Other, "Missing installation destination")
         })?;
 
         pb.set_message(&format!("{}", style("installing").yellow()));

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -37,6 +37,8 @@ cluFlock = "=0.1.5"
 winapi = { version = "0.3", features = ["winver","memoryapi"] }
 libc = "0.2.43"
 tempfile = "3"
+[target.'cfg(target_os = "linux")'.dependencies]
+unzip = "0.1.0"
 
 [dev-dependencies]
 proptest = "0.8.7"

--- a/uvm_core/src/install/installer/linux.rs
+++ b/uvm_core/src/install/installer/linux.rs
@@ -1,0 +1,302 @@
+use std::io;
+use std::path::PathBuf;
+use std::fs::File;
+use std::fs::DirBuilder;
+use std::ffi::{OsString, OsStr};
+use std::fs;
+use unzip::Unzipper;
+use std::process::{Command, Stdio};
+use std::io::Write;
+use std::io::Read;
+
+pub fn install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    _install_editor(installer, destination)
+    .map_err(|err| {
+        if destination.exists() {
+            debug!("Delete destination directory after failure {}", destination.display());
+            fs::remove_dir_all(destination).unwrap_or_else(|err| {
+                error!("Failed to cleanup destination {}", destination.display());
+                error!("{}", err);
+            })
+        }
+        err
+    })
+}
+
+fn _install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    debug!(
+        "install editor to destination: {} with installer: {}",
+        destination.display(),
+        installer.display()
+    );
+
+    if installer.extension() == Some(OsStr::new("zip")) {
+        debug!("install editor from zip archive");
+        cleanDirectory(destination)?;
+        deploy_zip(installer, destination)?;
+        return Ok(());
+    } else if installer.extension() == Some(OsStr::new("xz")) {
+        debug!("install editor from xz archive");
+        cleanDirectory(destination)?;
+        untar(installer, destination)?;
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        format!("Wrong installer. Expect .zip or .xz {:?} - {}", &installer.extension(), &installer.display()),
+    ))
+}
+
+pub fn install_module(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    _install_module(installer, destination)
+    .map_err(|err| {
+        if destination.exists() {
+            debug!("Delete destination directory after failure {}", destination.display());
+            fs::remove_dir_all(destination).unwrap_or_else(|err| {
+                error!("Failed to cleanup destination {}", destination.display());
+                error!("{}", err);
+            })
+        }
+        err
+    })
+}
+
+fn _install_module(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    debug!(
+        "install component {} to {}",
+        &installer.display(),
+        &destination.display()
+    );
+
+    if installer.extension() == Some(OsStr::new("zip")) {
+        debug!("install component from zip archive");
+        cleanDirectory(destination)?;
+        deploy_zip(installer, destination)?;
+        return Ok(());
+    } else if installer.extension() == Some(OsStr::new("xz")) {
+        let destination = if destination.ends_with("Editor/Data/PlaybackEngines") {
+            destination.parent()
+                .and_then(|f| f.parent())
+                .and_then(|f| f.parent())
+                .ok_or_else(|| io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Can't determine destination for {} and destination {}", &installer.display(), destination.display()),
+                ))?
+        } else {
+            destination
+        };
+
+        DirBuilder::new().recursive(true).create(destination)?;
+        untar(installer, &destination.to_path_buf())?;
+        return Ok(());
+    } else if installer.extension() == Some(OsStr::new("po")) {
+        debug!("install component po file");
+        let destination = destination.join(installer.file_name().unwrap().to_str().unwrap());
+        fs::copy(installer, destination)?;
+        return Ok(());
+    } else if installer.extension() == Some(OsStr::new("pkg")) {
+        debug!("install component from pkg archive");
+        let tmp_destination = destination.join("tmp");
+        DirBuilder::new().recursive(true).create(&tmp_destination)?;
+        xar_pkg(installer, &tmp_destination)?;
+        untar_pkg(&tmp_destination, destination)?;
+        cleanup_pkg(&tmp_destination)?;
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        format!("Wrong installer. Expect .pkg, .zip, .xz or .po {}", &installer.display()),
+    ))
+}
+
+fn xar_pkg(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    debug!(
+        "unpack installer {} to temp destination {}",
+        installer.display(),
+        destination.display()
+    );
+
+    let child = Command::new("7z")
+        .arg("x")
+        .arg("-y")
+        .arg(format!("-o{}", destination.display()))
+        .arg(installer)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "failed to extract installer:/n{}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_pkg(tmp_destination: &PathBuf) -> io::Result<()> {
+    debug!("cleanup {}", &tmp_destination.display());
+    fs::remove_dir_all(tmp_destination)
+}
+
+fn find_payload(dir: &PathBuf) -> io::Result<PathBuf> {
+    debug!("find paylod in unpacked installer {}", dir.display());
+    let mut files = fs::read_dir(dir).and_then(|read_dir| {
+        Ok(read_dir.filter_map(io::Result::ok))
+    }).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "can't iterate files in extracted payload {}",
+                &dir.display()
+            ),
+        )
+    })?;
+
+    files.find(|entry| {
+        if let Some(file_name) = entry.file_name().to_str() {
+            if file_name.ends_with(".pkg.tmp") || file_name == "Payload~" {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    })
+    .ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "can't locate *.pkg.tmp directory or Payload~ in extracted installer at {}",
+                &dir.display()
+            ),
+        )
+    })
+    .map(|entry| entry.path())
+    .and_then(|path| {
+        if path.file_name() == Some(OsStr::new("Payload~")) {
+            Ok(path)
+        } else {
+            let payload_path = path.join("Payload");
+            if payload_path.exists() {
+                Ok(payload_path)
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "can't locate Payload directory in extracted installer at {}",
+                        &dir.display()
+                    ),
+                ))
+            }
+        }
+    })
+    .map(|path| {
+        debug!("Found payload {}", path.display());
+        path
+    })
+}
+
+fn untar_pkg(base_payload_path: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    let payload = find_payload(&base_payload_path)?;
+    debug!("extract payload at {}", payload.display());
+
+    let tar_child = if payload.file_name() == Some(OsStr::new("Payload~")) {
+        let mut cpio = Command::new("cpio")
+            .arg("-iu")
+            .current_dir(destination)
+            .stdin(Stdio::piped())
+            .spawn()?;
+        {
+            let mut stdin = cpio.stdin.as_mut().expect("stdin");
+            let mut file = File::open(payload)?;
+            let mut buffer = Vec::new();
+            file.read_to_end(&mut buffer)?;
+            stdin.write(&buffer)?;
+        }
+        cpio
+    } else {
+        let mut gzip = Command::new("gzip")
+            .arg("-dc")
+            .arg(payload)
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+            let mut cpio = Command::new("cpio")
+                .arg("-iu")
+                .current_dir(destination)
+                .stdin(Stdio::piped())
+                .spawn()?;
+            {
+                let mut stdin = cpio.stdin.as_mut().expect("stdin");
+                let mut gzipStdOut = gzip.stdout.as_mut().expect("stdout");
+                let mut buffer = Vec::new();
+                gzipStdOut.read_to_end(&mut buffer)?;
+                stdin.write(&buffer)?;
+            }
+            cpio
+    };
+
+    let tar_output = tar_child.wait_with_output()?;
+    if !tar_output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "failed to untar payload:/n{}",
+                String::from_utf8_lossy(&tar_output.stderr)
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn cleanDirectory(path: &PathBuf) -> io::Result<()> {
+    debug!("clean output directory {}", path.display());
+    if path.exists() {
+        debug!("directory exists. Delete directory and create empty directory at {}", path.display());
+        fs::remove_dir_all(path)?;
+    }
+    DirBuilder::new().recursive(true).create(path)
+}
+
+fn deploy_zip(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    let file = File::open(installer)?;
+    let unzipper = Unzipper::new(file, destination);
+    unzipper.unzip()?;
+
+    Ok(())
+}
+
+fn untar(source: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    debug!("untar archive {} to {}", source.display(), destination.display());
+    let tar_child = Command::new("tar")
+        .arg("-C")
+        .arg(destination)
+        .arg("-amxf")
+        .arg(source)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let tar_output = tar_child.wait_with_output()?;
+    if !tar_output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "failed to untar payload:/n{}",
+                String::from_utf8_lossy(&tar_output.stderr)
+            ),
+        ));
+    }
+
+    Ok(())
+}

--- a/uvm_core/src/install/installer/macos.rs
+++ b/uvm_core/src/install/installer/macos.rs
@@ -7,6 +7,20 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 pub fn install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    _install_editor(installer, destination)
+    .map_err(|err| {
+        if destination.exists() {
+            debug!("Delete destination directory after failure {}", destination.display());
+            fs::remove_dir_all(destination).unwrap_or_else(|err| {
+                error!("Failed to cleanup destination {}", destination.display());
+                error!("{}", err);
+            })
+        }
+        err
+    })
+}
+
+fn _install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
     debug!(
         "install editor to destination: {} with installer: {}",
         destination.display(),
@@ -31,6 +45,20 @@ pub fn install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<
 }
 
 pub fn install_module(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+    _install_module(installer, destination)
+    .map_err(|err| {
+        if destination.exists() {
+            debug!("Delete destination directory after failure {}", destination.display());
+            fs::remove_dir_all(destination).unwrap_or_else(|err| {
+                error!("Failed to cleanup destination {}", destination.display());
+                error!("{}", err);
+            })
+        }
+        err
+    })
+}
+
+fn _install_module(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
     debug!(
         "install component {} to {}",
         &installer.display(),

--- a/uvm_core/src/install/installer/mod.rs
+++ b/uvm_core/src/install/installer/mod.rs
@@ -1,18 +1,22 @@
 #[cfg(target_os = "macos")]
 mod macos;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-mod other;
 #[cfg(target_os = "windows")]
 mod windows;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+mod other;
 
 mod loader;
 
 #[cfg(target_os = "macos")]
 use self::macos as sys;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-use self::other as sys;
 #[cfg(target_os = "windows")]
 use self::windows as sys;
+#[cfg(target_os = "linux")]
+use self::linux as sys;
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+use self::other as sys;
 
 pub use self::sys::install_editor;
 pub use self::sys::install_module;

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -9,6 +9,9 @@ extern crate serde;
 extern crate serde_ini;
 extern crate serde_json;
 extern crate serde_yaml;
+#[cfg(target_os = "linux")]
+extern crate unzip;
+
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -64,12 +64,29 @@ impl Component {
         path.map(|p| Path::new(p).to_path_buf())
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn installpath(self) -> Option<PathBuf> {
+        let path = match self {
+            StandardAssets => Some("Editor/Standard Assets"),
+            Android => Some("Editor/Data/PlaybackEngines/AndroidPlayer"),
+            Ios => Some("Editor/Data/PlaybackEngines/iOSSupport"),
+            TvOs => Some("Editor/Data/PlaybackEngines/AppleTVSupport"),
+            //Linux => Some("Editor/Data/PlaybackEngines/LinuxStandaloneSupport"),
+            Windows => Some("Editor/Data/PlaybackEngines/windowsstandalonesupport"),
+            WindowsMono => Some("Editor/Data/PlaybackEngines/windowsstandalonesupport"),
+            WebGl => Some("Editor/Data/PlaybackEngines/WebGLSupport"),
+            _ => None,
+        };
+
+        path.map(|p| Path::new(p).to_path_buf())
+    }
+
     #[cfg(target_os = "windows")]
     pub fn installpath(self) -> Option<PathBuf> {
         None
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     pub fn install_location(self) -> Option<PathBuf> {
         self.installpath()
     }

--- a/uvm_core/src/unity/hub/paths.rs
+++ b/uvm_core/src/unity/hub/paths.rs
@@ -2,8 +2,11 @@ use std::fs::File;
 use std::path::PathBuf;
 
 pub fn default_install_path() -> Option<PathBuf> {
-    dirs_2::application_dir()
-        .map(|path| path.join(["Unity", "Hub", "Editor"].iter().collect::<PathBuf>()))
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    let application_path = dirs_2::application_dir();
+    #[cfg(target_os = "linux")]
+    let application_path = dirs_2::home_dir();
+    application_path.map(|path| path.join(["Unity", "Hub", "Editor"].iter().collect::<PathBuf>()))
 }
 
 pub fn install_path() -> Option<PathBuf> {
@@ -21,7 +24,11 @@ pub fn install_path() -> Option<PathBuf> {
 }
 
 pub fn config_path() -> Option<PathBuf> {
-    dirs_2::data_dir().map(|path| path.join("UnityHub"))
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    return dirs_2::data_dir().map(|path| path.join("UnityHub"));
+
+    #[cfg(target_os = "linux")]
+    return dirs_2::config_dir().map(|path| path.join("UnityHub"));
 }
 
 pub fn editors_config_path() -> Option<PathBuf> {

--- a/uvm_core/src/unity/installation.rs
+++ b/uvm_core/src/unity/installation.rs
@@ -19,7 +19,7 @@ pub trait UnityInstallation: Eq + Ord {
 
     #[cfg(target_os = "windows")]
     fn location(&self) -> PathBuf {
-        self.path().join("Editor/Unity.exe")
+        self.path().join("Editor\\Unity.exe")
     }
 
     #[cfg(target_os = "macos")]
@@ -27,7 +27,12 @@ pub trait UnityInstallation: Eq + Ord {
         self.path().join("Unity.app")
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(target_os = "linux")]
+    fn location(&self) -> PathBuf {
+        self.path().join("Editor/Unity")
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     fn exec_path(&self) -> PathBuf {
         self.location()
     }
@@ -104,7 +109,24 @@ fn adjust_path(path:&Path) -> Option<&Path> {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
+fn adjust_path(path:&Path) -> Option<&Path> {
+    if path.is_file() {
+        if let Some(name) = path.file_name() {
+            if name == "Unity" {
+                path.parent().and_then(|path| path.parent())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 fn adjust_path(path:&Path) -> Option<&Path> {
     None
 }
@@ -117,6 +139,7 @@ impl Installation {
         } else {
             path
         };
+
         version::read_version_from_path(&path)
             .map(|version| Installation {
                 version,
@@ -144,7 +167,7 @@ impl Installation {
 
     #[cfg(target_os = "windows")]
     pub fn location(&self) -> PathBuf {
-        self.path().join("Editor/Unity.exe")
+        self.path().join("Editor\\Unity.exe")
     }
 
     #[cfg(target_os = "macos")]
@@ -152,7 +175,12 @@ impl Installation {
         self.path().join("Unity.app")
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(target_os = "linux")]
+    pub fn location(&self) -> PathBuf {
+        self.path().join("Editor/Unity")
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     pub fn exec_path(&self) -> PathBuf {
         self.location()
     }

--- a/uvm_core/src/unity/urls.rs
+++ b/uvm_core/src/unity/urls.rs
@@ -70,13 +70,15 @@ impl Into<Url> for IniUrl {
 }
 
 impl IniUrl {
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
     pub fn new<V: AsRef<Version>>(version: V) -> Result<IniUrl> {
         let version = version.as_ref();
         let download_url = DownloadURL::new(version)?;
 
         let os = if cfg!(target_os = "macos") {
             "osx"
+        } else if cfg!(target_os = "linux") {
+            "linux"
         } else {
             "win"
         };
@@ -87,7 +89,7 @@ impl IniUrl {
         Ok(IniUrl(url))
     }
 
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     pub fn new<V: AsRef<Version>>(version: V) -> Result<IniUrl> {
         unimplemented!()
     }

--- a/uvm_core/src/unity/version/linux.rs
+++ b/uvm_core/src/unity/version/linux.rs
@@ -1,0 +1,36 @@
+use super::*;
+use std::convert::AsRef;
+use std::io;
+use std::path::Path;
+
+pub fn read_version_from_path<P: AsRef<Path>>(path: P) -> Result<Version> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Provided Path does not exist. {}", path.display(),),
+        )
+        .into());
+    }
+
+    if path.is_dir() {
+        //check for the `Unity.exe`
+        let executable_path = path.join("Editor/Unity");
+        trace!(
+            "executable_path {} exists: {}",
+            executable_path.display(),
+            executable_path.exists()
+        );
+
+        if executable_path.exists() {
+            let path_name = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+                debug!("Unable to read filename from path {}", path.display());
+                UvmVersionErrorKind::FailedToReadVersion(path.display().to_string())
+            })?;
+
+            return Version::from_str(path_name);
+        }
+    }
+
+    Err(UvmVersionErrorKind::NotAUnityInstalltion(path.display().to_string()).into())
+}

--- a/uvm_core/src/unity/version/mod.rs
+++ b/uvm_core/src/unity/version/mod.rs
@@ -13,17 +13,21 @@ pub mod manifest;
 
 #[cfg(target_os = "macos")]
 mod mac;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-mod other;
 #[cfg(target_os = "windows")]
 mod win;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+mod other;
 
 #[cfg(target_os = "macos")]
 use self::mac as sys;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-use self::other as sys;
 #[cfg(target_os = "windows")]
 use self::win as sys;
+#[cfg(target_os = "linux")]
+use self::linux as sys;
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+use self::other as sys;
 
 pub use self::hash::all_versions;
 pub use self::sys::read_version_from_path;
@@ -226,6 +230,16 @@ error_chain! {
         NotAUnityInstalltion(path: String) {
             description("path is not a unity installtion"),
             display("Provided Path: '{}' is not a Unity installation.", path),
+        }
+
+        FailedToReadVersion(path: String) {
+            description("unable to read version from path"),
+            display("Unable to read version from path: '{}'.", path),
+        }
+
+        IllegalOperation(t: String) {
+            description("illegal operation"),
+            display("illegal operation: '{}'", t),
         }
     }
 }

--- a/uvm_core/src/unity/version/other.rs
+++ b/uvm_core/src/unity/version/other.rs
@@ -1,12 +1,10 @@
 use super::*;
-use crate::error::IllegalOperationError;
-use crate::result::Result;
 use std::convert::AsRef;
 use std::path::Path;
 
 pub fn read_version_from_path<P: AsRef<Path>>(path: P) -> Result<Version> {
     Err(
-        IllegalOperationError::new("fn 'read_version_from_path' not supported on current platform")
-            .into(),
+        UvmErrorKind::IllegalOperationError("fn 'read_version_from_path' not supported on current platform")
+        .into(),
     )
 }


### PR DESCRIPTION
## Description

This patch adds expirimtal support for the linux platform. It contains a new installation routine for linux to install Unity editor versions and components. As of this point not all Editor versions are available. This needs to be verified and maybe the versions endpoint should be updated to reflect that.

The linux default installation, config and cache paths follow the paths configured in UnityHub

installation location: `$HOME/Unity/Hub/Editor/`
config location: `($XDG_CONFIG_HOME|$HOME/.config)/UnityHub`
cache location: `($XDG_CACHE_HOME|$HOME/.config)/Wooga/UnityVersionManager`

## Changes

* ![ADD] Linux support

[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"