### PR TITLE
Fix adjust_path for installation on windows OS

### DIFF
--- a/uvm_core/src/unity/installation.rs
+++ b/uvm_core/src/unity/installation.rs
@@ -92,9 +92,7 @@ fn adjust_path(path:&Path) -> Option<&Path> {
     if path.is_file() {
         if let Some(name) = path.file_name() {
             if name == "Unity.exe" {
-                path.parent()
-                    .and_then(|path| path.parent())
-                    .and_then(|path| path.parent())
+                path.parent().and_then(|path| path.parent())
             } else {
                 None
             }


### PR DESCRIPTION
## Description

The helper method `adjust_path` that checks if the proved path to a unity installation is pointing to a Unity executable adjusted the path incorrect. In windows the path to the executable inside of an
installation is as follows:

`installation_dir\Editor\Unity.exe`

We need to get the parent of the `Editor` directory. The incorrect implementation did one `parent` to much.

## Changes

* ![FIX] `adjust_path` implementation for windows

[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"