### PR TITLE
Switch to Rust Edition 2018

### DIFF
--- a/commands/uvm-clear/Cargo.toml
+++ b/commands/uvm-clear/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-clear"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 serde = "1.0"

--- a/commands/uvm-clear/src/lib.rs
+++ b/commands/uvm-clear/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+use uvm_core;
 #[macro_use]
 extern crate error_chain;
 

--- a/commands/uvm-clear/src/main.rs
+++ b/commands/uvm-clear/src/main.rs
@@ -1,7 +1,7 @@
-extern crate console;
-extern crate uvm_clear;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_clear;
+use uvm_cli;
+
 
 use uvm_clear::ClearOptions;
 

--- a/commands/uvm-commands/Cargo.toml
+++ b/commands/uvm-commands/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-commands"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 serde = "1.0"

--- a/commands/uvm-commands/src/lib.rs
+++ b/commands/uvm-commands/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+
 
 use console::Style;
 use console::Term;

--- a/commands/uvm-commands/src/main.rs
+++ b/commands/uvm-commands/src/main.rs
@@ -1,5 +1,5 @@
-extern crate uvm_cli;
-extern crate uvm_commands;
+use uvm_cli;
+use uvm_commands;
 
 use uvm_commands::CommandsOptions;
 

--- a/commands/uvm-current/Cargo.toml
+++ b/commands/uvm-current/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-current"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 serde = "1.0"

--- a/commands/uvm-current/src/lib.rs
+++ b/commands/uvm-current/src/lib.rs
@@ -1,6 +1,6 @@
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+use uvm_core;
 #[macro_use]
 extern crate serde_derive;
 

--- a/commands/uvm-current/src/main.rs
+++ b/commands/uvm-current/src/main.rs
@@ -1,5 +1,5 @@
-extern crate uvm_cli;
-extern crate uvm_current;
+use uvm_cli;
+use uvm_current;
 
 use uvm_current::CurrentOptions;
 

--- a/commands/uvm-detect/Cargo.toml
+++ b/commands/uvm-detect/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-detect"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 uvm_cli = { path = "../../uvm_cli" }

--- a/commands/uvm-detect/src/main.rs
+++ b/commands/uvm-detect/src/main.rs
@@ -1,6 +1,6 @@
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+use uvm_core;
 
 use console::style;
 use std::env;

--- a/commands/uvm-help/Cargo.toml
+++ b/commands/uvm-help/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-help"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 uvm_cli = { path = "../../uvm_cli" }

--- a/commands/uvm-help/src/main.rs
+++ b/commands/uvm-help/src/main.rs
@@ -1,6 +1,6 @@
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+
 
 use std::process;
 use uvm_cli::HelpOptions;

--- a/commands/uvm-launch/Cargo.toml
+++ b/commands/uvm-launch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-launch"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 uvm_cli = { path = "../../uvm_cli" }

--- a/commands/uvm-launch/src/main.rs
+++ b/commands/uvm-launch/src/main.rs
@@ -1,6 +1,6 @@
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+use uvm_core;
 
 use console::style;
 use std::env;

--- a/commands/uvm-list/Cargo.toml
+++ b/commands/uvm-list/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-list"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 log = "0.4.5"

--- a/commands/uvm-list/src/lib.rs
+++ b/commands/uvm-list/src/lib.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate log;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+
+use uvm_cli;
+use uvm_core;
 
 use console::Style;
 use console::Term;

--- a/commands/uvm-list/src/main.rs
+++ b/commands/uvm-list/src/main.rs
@@ -1,5 +1,5 @@
-extern crate uvm_cli;
-extern crate uvm_list;
+use uvm_cli;
+use uvm_list;
 
 use uvm_list::ListOptions;
 

--- a/commands/uvm-use/Cargo.toml
+++ b/commands/uvm-use/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-use"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 uvm_cli = { path = "../../uvm_cli" }

--- a/commands/uvm-use/src/main.rs
+++ b/commands/uvm-use/src/main.rs
@@ -1,6 +1,6 @@
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+use uvm_core;
 
 use console::style;
 use std::process;

--- a/commands/uvm/Cargo.toml
+++ b/commands/uvm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 uvm_cli = { path = "../../uvm_cli" }

--- a/commands/uvm/src/main.rs
+++ b/commands/uvm/src/main.rs
@@ -1,5 +1,5 @@
-extern crate console;
-extern crate uvm_cli;
+
+use uvm_cli;
 
 use std::process;
 use uvm_cli::UvmOptions;

--- a/install/uvm-install-editor/Cargo.toml
+++ b/install/uvm-install-editor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-install-editor"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 flexi_logger = "0.9.2"
 log = "0.4.5"

--- a/install/uvm-install-editor/src/lib.rs
+++ b/install/uvm-install-editor/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+use uvm_cli;
+
 
 use console::style;
 use console::Term;

--- a/install/uvm-install-editor/src/main.rs
+++ b/install/uvm-install-editor/src/main.rs
@@ -1,7 +1,7 @@
-extern crate console;
-extern crate flexi_logger;
-extern crate uvm_cli;
-extern crate uvm_install_editor;
+
+
+use uvm_cli;
+use uvm_install_editor;
 
 const USAGE: &str = "
 uvm-install-editor - Install a unity editor from given installer.

--- a/install/uvm-install/Cargo.toml
+++ b/install/uvm-install/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-install"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 flexi_logger = "0.9.2"
 indicatif = "0.11.0"

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate indicatif;
-extern crate serde;
-extern crate uvm_cli;
+
+use indicatif;
+
+use uvm_cli;
 #[macro_use]
 extern crate uvm_core;
 

--- a/install/uvm-install/src/main.rs
+++ b/install/uvm-install/src/main.rs
@@ -1,7 +1,7 @@
-extern crate console;
-extern crate flexi_logger;
-extern crate uvm_cli;
-extern crate uvm_install;
+
+
+use uvm_cli;
+use uvm_install;
 
 #[macro_use]
 extern crate log;

--- a/install/uvm-uninstall/Cargo.toml
+++ b/install/uvm-uninstall/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-uninstall"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 serde = "1.0"

--- a/install/uvm-uninstall/src/lib.rs
+++ b/install/uvm-uninstall/src/lib.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate serde;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+
+
+
 
 use console::style;
 use console::Term;

--- a/install/uvm-uninstall/src/main.rs
+++ b/install/uvm-uninstall/src/main.rs
@@ -1,6 +1,6 @@
-extern crate console;
-extern crate uvm_cli;
-extern crate uvm_uninstall;
+
+use uvm_cli;
+use uvm_uninstall;
 
 #[macro_use]
 extern crate log;

--- a/install/uvm-versions/Cargo.toml
+++ b/install/uvm-versions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm-versions"
 version = "2.1.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 console = "0.6.1"
 regex = "0.2"

--- a/install/uvm-versions/src/lib.rs
+++ b/install/uvm-versions/src/lib.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate console;
-extern crate indicatif;
-extern crate itertools;
-extern crate regex;
-extern crate serde;
-extern crate uvm_cli;
-extern crate uvm_core;
+
+
+
+
+use serde;
+use uvm_cli;
+use uvm_core;
 #[macro_use]
 extern crate log;
 
@@ -185,7 +185,7 @@ impl UvmCommand {
                     entry.get_mut().insert(version);
                 }
                 Vacant(entry) => {
-                    let mut versions: VersionSet = VersionSet::with_capacity(1);
+                    let versions: VersionSet = VersionSet::with_capacity(1);
                     entry.insert(versions);
                 }
             };

--- a/install/uvm-versions/src/main.rs
+++ b/install/uvm-versions/src/main.rs
@@ -1,8 +1,8 @@
-extern crate uvm_cli;
-extern crate uvm_versions;
+use uvm_cli;
+use uvm_versions;
 #[macro_use]
 extern crate log;
-extern crate console;
+
 
 use console::style;
 use std::process;

--- a/uvm_cli/Cargo.toml
+++ b/uvm_cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uvm_cli"
 version = "2.0.1"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
-
+edition = "2018"
 [dependencies]
 flexi_logger = "0.9.2"
 log = "0.4.5"

--- a/uvm_cli/src/launch.rs
+++ b/uvm_cli/src/launch.rs
@@ -24,7 +24,7 @@ pub enum UnityPlatform {
 }
 
 impl Display for UnityPlatform {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let raw = format!("{:?}", self).to_lowercase();
         write!(f, "{}", raw)
     }

--- a/uvm_cli/src/lib.rs
+++ b/uvm_cli/src/lib.rs
@@ -1,12 +1,12 @@
-#[macro_use]
-extern crate serde_derive;
-extern crate cli_core;
-extern crate console;
-extern crate serde;
-extern crate uvm_core;
+
+
+
+
 #[macro_use]
 extern crate log;
-extern crate flexi_logger;
+#[macro_use]
+extern crate serde_derive;
+
 
 mod detect;
 mod help;

--- a/uvm_cli/src/utils.rs
+++ b/uvm_cli/src/utils.rs
@@ -56,7 +56,7 @@ fn check_file(entry: &fs::DirEntry) -> io::Result<bool> {
     Ok(!metadata.is_dir() && file_name.starts_with("uvm-") && file_name.ends_with(".exe"))
 }
 
-pub fn find_commands_in_path(dir: &Path) -> io::Result<Box<Iterator<Item = PathBuf>>> {
+pub fn find_commands_in_path(dir: &Path) -> io::Result<Box<dyn Iterator<Item = PathBuf>>> {
     let result = dir
         .read_dir()?
         .filter_map(io::Result::ok)
@@ -104,7 +104,7 @@ pub fn sub_command_path(command_name: &str) -> io::Result<PathBuf> {
     ))
 }
 
-pub struct UvmSubCommands(Box<Iterator<Item = UvmSubCommand>>);
+pub struct UvmSubCommands(Box<dyn Iterator<Item = UvmSubCommand>>);
 
 impl UvmSubCommands {
     fn new() -> io::Result<UvmSubCommands> {

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 keywords = ["unity","version-manager"]
 categories = ["development-tools"]
 license = "Apache-2.0"
+edition = "2018"
 [badges]
 travis-ci = { repository = "Larusso/unity-version-manager", branch = "master" }
 appveyor = { repository = "Larusso/unity-version-manager", branch = "master", service = "github" }

--- a/uvm_core/src/error.rs
+++ b/uvm_core/src/error.rs
@@ -4,9 +4,9 @@ error_chain! {
     }
 
     links {
-        VersionError(::unity::UvmVersionError, ::unity::UvmVersionErrorKind);
-        HubError(::unity::hub::UvmHubError, ::unity::hub::UvmHubErrorKind);
-        InstallError(::install::UvmInstallError, ::install::UvmInstallErrorKind);
+        VersionError(crate::unity::UvmVersionError, crate::unity::UvmVersionErrorKind);
+        HubError(crate::unity::hub::UvmHubError, crate::unity::hub::UvmHubErrorKind);
+        InstallError(crate::install::UvmInstallError, crate::install::UvmInstallErrorKind);
     }
 
     foreign_links {

--- a/uvm_core/src/install/installer/loader.rs
+++ b/uvm_core/src/install/installer/loader.rs
@@ -1,5 +1,5 @@
-use install::error::{Result, UvmInstallError, UvmInstallErrorKind};
-use install::InstallVariant;
+use crate::install::error::{Result, UvmInstallError, UvmInstallErrorKind};
+use crate::install::InstallVariant;
 use md5::{Digest, Md5};
 use reqwest::header::{RANGE, USER_AGENT};
 use reqwest::StatusCode;
@@ -7,9 +7,9 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
-use unity::hub::paths;
-use unity::{Component, Manifest, Version, MD5};
-use ::progress::ProgressHandler;
+use crate::unity::hub::paths;
+use crate::unity::{Component, Manifest, Version, MD5};
+use crate::progress::ProgressHandler;
 use std::io::Read;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
@@ -39,7 +39,7 @@ pub struct Loader<'a> {
     variant: InstallVariant,
     version: Version,
     verify: bool,
-    progress_handle: Option<Box<&'a ProgressHandler>>
+    progress_handle: Option<Box<&'a dyn ProgressHandler>>
 }
 
 impl<'a> Loader<'a> {

--- a/uvm_core/src/install/mod.rs
+++ b/uvm_core/src/install/mod.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use unity::Version;
+use crate::unity::Version;
 pub mod error;
 mod installer;
 mod variant;
@@ -14,6 +14,6 @@ pub use self::installer::install_module;
 pub use self::variant::InstallVariant;
 
 pub fn download_installer(variant: InstallVariant, version: &Version) -> Result<PathBuf> {
-    let mut d = Loader::new(variant, version.to_owned());
+    let d = Loader::new(variant, version.to_owned());
     d.download()
 }

--- a/uvm_core/src/install/variant.rs
+++ b/uvm_core/src/install/variant.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use unity::Component;
+use crate::unity::Component;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum InstallVariant {
@@ -13,7 +13,7 @@ pub enum InstallVariant {
 }
 
 impl fmt::Display for InstallVariant {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             InstallVariant::Android => write!(f, "android"),
             InstallVariant::Ios => write!(f, "ios"),

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -1,14 +1,13 @@
 #![recursion_limit = "1024"]
-#[cfg(unix)]
-extern crate cluFlock;
-extern crate md5;
-extern crate regex;
-extern crate reqwest;
-extern crate semver;
-extern crate serde;
-extern crate serde_ini;
-extern crate serde_json;
-extern crate serde_yaml;
+
+
+
+
+
+
+
+
+
 #[cfg(target_os = "linux")]
 extern crate unzip;
 
@@ -19,14 +18,13 @@ extern crate lazy_static;
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
-extern crate plist;
-#[cfg(test)]
-extern crate rand;
-extern crate tempfile;
+
+
+
 #[macro_use]
 extern crate serde_derive;
-extern crate dirs_2;
-extern crate itertools;
+
+
 
 #[macro_use]
 extern crate error_chain;
@@ -39,7 +37,7 @@ pub mod progress;
 macro_rules! lock_process {
     ($lock_path:expr) => {
         let lock_file = fs::File::create($lock_path)?;
-        let _lock = ::utils::lock_process_or_wait(&lock_file)?;
+        let _lock = crate::utils::lock_process_or_wait(&lock_file)?;
     };
 }
 

--- a/uvm_core/src/unity/component.rs
+++ b/uvm_core/src/unity/component.rs
@@ -130,7 +130,7 @@ impl ParseComponentError {
 }
 
 impl fmt::Display for ParseComponentError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ParseComponentError")
     }
 }
@@ -142,7 +142,7 @@ impl Error for ParseComponentError {
 }
 
 impl fmt::Display for Component {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Component::Editor => write!(f, "editor"),
             Component::Mono => write!(f, "mono"),

--- a/uvm_core/src/unity/current_installation.rs
+++ b/uvm_core/src/unity/current_installation.rs
@@ -1,7 +1,7 @@
-use error::*;
+use crate::error::*;
 
 use std::path::Path;
-use unity::Installation;
+use crate::unity::Installation;
 
 pub type CurrentInstallation = Installation;
 const UNITY_CURRENT_LOCATION: &str = "/Applications/Unity";
@@ -30,7 +30,7 @@ mod tests {
     use std::path::PathBuf;
     use std::str::FromStr;
     use tempfile::Builder;
-    use unity::installation::AppInfo;
+    use crate::unity::installation::AppInfo;
 
     fn create_test_path(base_dir: &PathBuf, version: &str) -> PathBuf {
         let path = base_dir.join(format!("Unity-{version}", version = version));

--- a/uvm_core/src/unity/hub/editors/convert.rs
+++ b/uvm_core/src/unity/hub/editors/convert.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::convert::From;
-use unity::Installation;
+use crate::unity::Installation;
 
 const INSTALLATION_BINARY: &str = "Unity.app";
 

--- a/uvm_core/src/unity/hub/mod.rs
+++ b/uvm_core/src/unity/hub/mod.rs
@@ -2,7 +2,7 @@ pub mod editors;
 pub mod paths;
 
 use std::io;
-use unity;
+use crate::unity;
 //
 
 error_chain! {

--- a/uvm_core/src/unity/installation.rs
+++ b/uvm_core/src/unity/installation.rs
@@ -1,9 +1,9 @@
-use error::*;
+use crate::error::*;
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
-use unity::version;
-use unity::InstalledComponents;
-use unity::Version;
+use crate::unity::version;
+use crate::unity::InstalledComponents;
+use crate::unity::Version;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -16,7 +16,7 @@ pub use self::version::Version;
 pub use self::version::VersionType;
 pub use self::version::{UvmVersionError, UvmVersionErrorKind};
 
-use error::*;
+use crate::error::*;
 use itertools::Itertools;
 use std::convert::From;
 use std::fs;
@@ -24,8 +24,8 @@ use std::io;
 use std::path::Path;
 use std::slice::Iter;
 
-pub struct Installations(Box<Iterator<Item = Installation>>);
-pub struct Versions(Box<Iterator<Item = Version>>);
+pub struct Installations(Box<dyn Iterator<Item = Installation>>);
+pub struct Versions(Box<dyn Iterator<Item = Version>>);
 
 pub struct InstalledComponents {
     installation: Installation,
@@ -185,7 +185,7 @@ mod tests {
     use std::path::PathBuf;
     use std::str::FromStr;
     use tempfile::Builder;
-    use unity::installation::AppInfo;
+    use crate::unity::installation::AppInfo;
 
     fn create_test_path(base_dir: &PathBuf, version: &str) -> PathBuf {
         let path = base_dir.join(format!("Unity-{version}", version = version));

--- a/uvm_core/src/unity/urls.rs
+++ b/uvm_core/src/unity/urls.rs
@@ -1,8 +1,8 @@
-use error::*;
+use crate::error::*;
 use reqwest::Url;
 use std::convert::Into;
 use std::ops::Deref;
-use unity::version::{Version, VersionType};
+use crate::unity::version::{Version, VersionType};
 
 const BASE_URL: &str = "https://download.unity3d.com/download_unity/";
 const BETA_BASE_URL: &str = "https://beta.unity3d.com/download/";

--- a/uvm_core/src/unity/version/hash.rs
+++ b/uvm_core/src/unity/version/hash.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
-use unity::hub::paths;
+use crate::unity::hub::paths;
 
 pub fn all_versions() -> io::Result<impl Iterator<Item = Version>> {
     let url = reqwest::Url::parse("https://unity-versions-service.herokuapp.com/").unwrap();

--- a/uvm_core/src/unity/version/manifest/mod.rs
+++ b/uvm_core/src/unity/version/manifest/mod.rs
@@ -1,4 +1,4 @@
-use error::*;
+use crate::error::*;
 use reqwest::header;
 use reqwest::Url;
 use serde_ini;
@@ -7,9 +7,9 @@ use std::fs::{DirBuilder, File};
 use std::io::{self, Write};
 use std::path::Path;
 use std::time::Duration;
-use unity::{Component, Version};
-use unity::hub::paths;
-use unity::urls::{DownloadURL, IniUrl};
+use crate::unity::{Component, Version};
+use crate::unity::hub::paths;
+use crate::unity::urls::{DownloadURL, IniUrl};
 
 lazy_static! {
     static ref CLIENT: reqwest::Client = {
@@ -63,7 +63,7 @@ impl Manifest {
             io::Error::new(io::ErrorKind::Other, "Unable to fetch cache directory")
         })?;
 
-        DirBuilder::new().recursive(true).create(&cache_dir).map_err(|err| {
+        DirBuilder::new().recursive(true).create(&cache_dir).map_err(|_err| {
             io::Error::new(io::ErrorKind::Other, format!("Unable to create cache directory at {}", cache_dir.display()))
         })?;
 

--- a/uvm_core/src/unity/version/mod.rs
+++ b/uvm_core/src/unity/version/mod.rs
@@ -6,7 +6,7 @@ use std::convert::{AsMut, AsRef, From};
 use std::fmt;
 use std::result;
 use std::str::FromStr;
-use unity::Installation;
+use crate::unity::Installation;
 
 mod hash;
 pub mod manifest;
@@ -173,7 +173,7 @@ impl From<(u64, u64, u64, u64)> for Version {
 }
 
 impl fmt::Display for VersionType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             match *self {
                 VersionType::Final => write!(f, "final"),
@@ -193,7 +193,7 @@ impl fmt::Display for VersionType {
 }
 
 impl fmt::Display for Version {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}{}{}",

--- a/uvm_core/tests/download_unity_installer.rs
+++ b/uvm_core/tests/download_unity_installer.rs
@@ -1,4 +1,4 @@
-extern crate uvm_core;
+
 use uvm_core::install;
 use uvm_core::unity;
 


### PR DESCRIPTION
## Description

This patch adds changes to switch to rust 2018 edition.

## Changes

* ![IMPROVE] switch to rust 2018 edition

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"