### PR TITLE
Improve unity::version::Manifest

### DIFF
--- a/uvm_core/src/install/installer/loader.rs
+++ b/uvm_core/src/install/installer/loader.rs
@@ -65,7 +65,7 @@ impl<'a> Loader<'a> {
             "download installer for variant: {} and version: {}",
             self.variant, self.version
         );
-        let manifest = Manifest::load(self.version.clone()).map_err(|err| {
+        let manifest = Manifest::load(&self.version).map_err(|err| {
             UvmInstallError::with_chain(err, UvmInstallErrorKind::ManifestLoadFailed)
         })?;
         let component: Component = self.variant.clone().into();

--- a/uvm_core/src/unity/version/manifest/de.rs
+++ b/uvm_core/src/unity/version/manifest/de.rs
@@ -1,0 +1,24 @@
+pub mod bool {
+    use serde::{Deserialize, Deserializer};
+    use std::result;
+
+    pub fn default() -> bool {
+        false
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> result::Result<bool, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.is_empty() {
+            Ok(false)
+        } else {
+            match s.as_str() {
+                "true" => Ok(true),
+                "false" => Ok(true),
+                _ => Ok(false),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Description
===========

A small refactoring for `unity::version::Manifest`. The version field `unity::Version` in this struct is now a reference. The manifest gets created with this version and doesn't need to own it. This patch also adds smaller additions for the contained structs in the `manifest.rs` file and some code reorderings.
The `ComponentData` struct contains a new field `download_url` which gets created after de-serializing the manifest ini file. This allows to fetch the download url of a component without having a reference to the manifest itself.

As a small cleanup I created a custom serde module in `de.rs` with
functions to deserialize `bool` values in ini files.

Changes
=======

* ![IMPROVE] `unity::version::Manifest`
* ![ADD] ![NEW] field `download_url` to `ComponentData`
* ![ADD] ![NEW] module `unity::version::manifest::de` with custom serde functions

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
