### PR TITLE
Add new API methods to create manifest from reader path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringreader"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2056,7 @@ dependencies = [
  "serde_ini 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unzip 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2334,6 +2340,7 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
+"checksum stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "913e7b03d63752f6cdd2df77da36749d82669904798fe8944b9ec3d23f159905"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)" = "37ea458a750f59ab679b47fef9b6722c586c5742f4cfe18a120bbc807e5e01fd"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -45,3 +45,4 @@ unzip = "0.1.0"
 [dev-dependencies]
 proptest = "0.8.7"
 rand = "0.5"
+stringreader = "0.1.1"

--- a/uvm_core/src/unity/version/manifest/mod.rs
+++ b/uvm_core/src/unity/version/manifest/mod.rs
@@ -43,6 +43,33 @@ impl<'a> Manifest<'a> {
         Self::get_manifest(version)
     }
 
+    pub fn read_manifest_version_from_path<P: AsRef<Path>>(manifest_path: P) -> Result<Version> {
+        let f = File::open(manifest_path)?;
+        Self::read_manifest_version(f)
+    }
+
+    pub fn read_manifest_version<R: Read>(mut reader: R) -> Result<Version> {
+        use std::str::FromStr;
+        let mut manifest_buffer = String::new();
+        reader.read_to_string(&mut manifest_buffer)?;
+        Version::from_str(&manifest_buffer).chain_err(|| "can't read version from manifest body")
+    }
+
+    pub fn from_reader<R: Read>(version: &'a Version, manifest: R) -> Result<Manifest<'a>> {
+        let base_url = DownloadURL::new(&version)?;
+        let components = Self::read_components(manifest, &base_url)?;
+        Ok(Manifest {
+            version,
+            base_url,
+            components,
+        })
+    }
+
+    pub fn new<P:AsRef<Path>>(version: &'a Version, manifest_path: P) -> Result<Manifest<'a>> {
+        let manifest = File::open(manifest_path)?;
+        Self::from_reader(version, manifest)
+    }
+
     pub fn get(&self, component: Component) -> Option<&ComponentData> {
         self.components.get(&component)
     }
@@ -94,14 +121,7 @@ impl<'a> Manifest<'a> {
         if !manifest_path.exists() {
             Self::download_manifest(version, manifest_path.to_path_buf())
         } else {
-            let base_url = DownloadURL::new(&version)?;
-            let manifest = File::open(manifest_path)?;
-            let components = Self::read_components(manifest, &base_url)?;
-            Ok(Manifest {
-                version,
-                base_url,
-                components,
-            })
+            Manifest::new(version, manifest_path)
         }
     }
 
@@ -229,6 +249,7 @@ mod tests {
     use std::fs;
     #[cfg(target_os = "macos")]
     use tempfile;
+    use stringreader::StringReader;
 
     #[cfg(target_os = "macos")]
     #[test]
@@ -313,6 +334,161 @@ mod tests {
         Manifest::download_manifest(&version, &path).unwrap();
         assert!(path.exists());
     }
+
+    #[test]
+    fn can_read_version_from_manifest_body() {
+        let test_ini = r#"[Section1]
+key=value
+[Section2]
+line which is not a section
+version = 2019.1.0f1
+line which is not a section or key=value
+line which is not a section or key = value
+key = "value with equals = ssjdd"
+key2=value2"#;
+        let test_ini = StringReader::new(test_ini);
+        let version = Manifest::read_manifest_version(test_ini).expect("a version from manifest");
+        assert_eq!(version, Version::f(2019,1,0,1));
+    }
+
+    #[test]
+    fn can_read_manifest_from_reader() {
+        let test_ini = r#"[Unity]
+title=Unity 2018.4.0f1
+description=Unity Editor
+url=MacEditorInstaller/Unity.pkg
+install=true
+mandatory=false
+size=989685761
+installedsize=2576390000
+version=2018.4.0f1
+md5=822c52aa75af582318c5d0ef94137f40
+[Mono]
+title=Mono for Visual Studio for Mac
+description=Required for Visual Studio for Mac
+url=https://go.microsoft.com/fwlink/?linkid=857641
+install=false
+mandatory=false
+size=500000000
+installedsize=1524000000
+sync=VisualStudio
+hidden=true
+extension=pkg
+[VisualStudio]
+title=Visual Studio for Mac
+description=Script IDE with Unity integration and debugging support. Also installs Mono, required for Visual Studio for Mac to run
+url=https://go.microsoft.com/fwlink/?linkid=873167
+install=true
+mandatory=false
+size=820000000
+installedsize=2304000000
+eulamessage=Please review and accept the license terms before downloading and installing Visual Studio for Mac and Mono.
+eulalabel1=Visual Studio for Mac License Terms
+eulaurl1=https://www.visualstudio.com/license-terms/visual-studio-mac-eula/
+eulalabel2=Mono License Terms
+eulaurl2=http://www.mono-project.com/docs/faq/licensing/
+appidentifier=com.microsoft.visual-studio
+extension=dmg
+[Android]
+title=Android Build Support
+description=Allows building your Unity projects for the Android platform
+url=MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=622757914
+installedsize=1885331000
+requires_unity=true
+md5=dba5dab1ded52b75a400171579dd3940
+[iOS]
+title=iOS Build Support
+description=Allows building your Unity projects for the iOS platform
+url=MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=1115793461
+installedsize=2847287000
+requires_unity=true
+md5=0d7a1a05d61d73d07205b74c73da7741
+[AppleTV]
+title=tvOS Build Support
+description=Allows building your Unity projects for the AppleTV platform
+url=MacEditorTargetInstaller/UnitySetup-AppleTV-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=379578397
+installedsize=1016195000
+requires_unity=true
+md5=7f429c1fc4a03d7bdef8fb9b73b393c5
+[Linux]
+title=Linux Build Support
+description=Allows building your Unity projects for the Linux platform
+url=MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=276383772
+installedsize=848256000
+requires_unity=true
+md5=02c0cd88959f7d28d9edb46d717a5efd
+[Mac-IL2CPP]
+title=Mac Build Support (IL2CPP)
+description=Allows building your Unity projects for the Mac-IL2CPP platform
+url=MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=86886432
+installedsize=310706000
+requires_unity=true
+md5=0b147e6349c798549f5a9742e9e6ac33
+[Vuforia-AR]
+title=Vuforia Augmented Reality Support
+description=Allows building your Unity projects for the Vuforia-AR platform
+url=MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=149641238
+installedsize=277990000
+requires_unity=true
+md5=b6d356215ebce9f3fb63984391755eec
+[WebGL]
+title=WebGL Build Support
+description=Allows building your Unity projects for the WebGL platform
+url=MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=324638752
+installedsize=882122000
+requires_unity=true
+md5=a5d8a2cc47081c50e238afb6e62a16ce
+[Windows-Mono]
+title=Windows Build Support (Mono)
+description=Allows building your Unity projects for the Windows-Mono platform
+url=MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=104425498
+installedsize=346767000
+requires_unity=true
+md5=5fccd81dbd8570dbddcd8d4cfcf7fbf1
+[Facebook-Games]
+title=Facebook Gameroom Build Support
+description=Allows building your Unity projects for the Facebook-Games platform
+url=MacEditorTargetInstaller/UnitySetup-Facebook-Games-Support-for-Editor-2018.4.0f1.pkg
+install=false
+mandatory=false
+size=46835742
+installedsize=111566000
+requires_unity=true
+md5=0aa3e9b0ec4942e783f63d768b8252f0
+optsync_windows=Windows
+optsync_webgl=WebGL"#;
+        let test_ini_1 = StringReader::new(test_ini);
+        let version = Manifest::read_manifest_version(test_ini_1).expect("a version from manifest");
+        let test_ini_2 = StringReader::new(test_ini);
+        let manifest = Manifest::from_reader(&version, test_ini_2).expect("a manifest from reader");
+        assert!(manifest.get(Component::Android).is_some());
+        assert!(manifest.get(Component::Ios).is_some());
+        assert!(manifest.get(Component::Editor).is_some());
+}
 
     #[test]
     fn cleanup_ini_data_removes_junk_lines() {


### PR DESCRIPTION
## Description

The current API of `unity::version::Manifest` allows only to load a manifest file with a specified version from the internet. If the manifest in question was cached the cached version was returned. This patch adds new API's to create `unity::version::Manifest` structs from `Read` or `Path`. Because of the internal structure of Manifest and the problem that a manifest has no idea about it's own version we need to parse the version before we can parse the rest of the file. This might be worth another refactor.

## Changes

* ![ADD] `read_manifest_version_from_path` in `unity::version::Manifest`
* ![ADD] `read_manifest_version` in `unity::version::Manifest`
* ![ADD] `from_reader` in `unity::version::Manifest`
* ![ADD] `new` in `unity::version::Manifest`

[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"