### PR TITLE
Add auxiliary command download-manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm-download-manifest"
+version = "0.1.0"
+dependencies = [
+ "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flexi_logger 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_cli 2.0.1",
+ "uvm_core 0.3.1",
+]
+
+[[package]]
 name = "uvm-generate-modules-json"
 version = "1.0.0"
 dependencies = [

--- a/commands/uvm-download-manifest/Cargo.toml
+++ b/commands/uvm-download-manifest/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uvm-download-manifest"
+version = "0.1.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+edition = "2018"
+
+[dependencies]
+console = "0.6.1"
+flexi_logger = "0.9.2"
+log = "0.4.5"
+reqwest = "0.9.4"
+serde = "1.0"
+serde_derive = "1.0"
+uvm_cli = { path = "../../uvm_cli" }
+uvm_core = { path = "../../uvm_core" }

--- a/commands/uvm-download-manifest/src/lib.rs
+++ b/commands/uvm-download-manifest/src/lib.rs
@@ -1,0 +1,111 @@
+use serde_derive::Deserialize;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::PathBuf;
+use uvm_cli;
+use uvm_cli::ColorOption;
+use uvm_core::unity::Version;
+use uvm_core::platform::Platform;
+
+#[derive(Debug, Deserialize)]
+pub struct Options {
+    arg_version: Version,
+
+    #[serde(default)]
+    flag_platform: Option<Platform>,
+    flag_output_dir: Option<PathBuf>,
+    flag_name: String,
+    flag_verbose: bool,
+    flag_force: bool,
+    flag_debug: bool,
+    flag_color: ColorOption,
+}
+
+pub enum Output {
+    File(File),
+    Stdout,
+}
+
+impl Default for Output {
+    fn default() -> Self {
+        Output::Stdout
+    }
+}
+
+impl Write for Output {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        use Output::*;
+        match self {
+            File(x) => x.write(buf),
+            _ => console::Term::stdout().write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        use Output::*;
+        match self {
+            File(x) => x.flush(),
+            _ => console::Term::stdout().flush(),
+        }
+    }
+}
+
+impl Options {
+    pub fn version(&self) -> &Version {
+        &self.arg_version
+    }
+
+    pub fn platform(&self) -> Platform {
+        self.flag_platform.unwrap_or_default()
+    }
+
+    pub fn name(&self) -> String {
+        let name = &self.flag_name;
+        let name = name.as_str().replace("{version}", &self.version().to_string());
+        let name = name.as_str().replace("{platform}", &self.platform().to_string());
+        name
+    }
+
+    pub fn output(&self) -> io::Result<impl Write> {
+        use std::fs::OpenOptions;
+        if let Some(path) = &self.flag_output_dir {
+            if !path.is_dir() {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, "output path is not a directory"))
+            } else {
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .create_new(!self.flag_force)
+                    .open(path.join(self.name()))
+                    .and_then(|f| Ok(Output::File(f)))
+            }
+
+        } else {
+            Ok(Output::default())
+        }
+    }
+
+    pub fn output_path(&self) -> Option<PathBuf> {
+        let path = self.flag_output_dir.as_ref()?;
+        if !path.is_dir() {
+            None
+        } else {
+            Some(path.join(self.name()))
+        }
+    }
+}
+
+impl uvm_cli::Options for Options {
+    fn verbose(&self) -> bool {
+        self.flag_verbose
+    }
+
+    fn debug(&self) -> bool {
+        self.flag_debug
+    }
+
+    fn color(&self) -> &ColorOption {
+        &self.flag_color
+    }
+}

--- a/commands/uvm-download-manifest/src/main.rs
+++ b/commands/uvm-download-manifest/src/main.rs
@@ -1,0 +1,72 @@
+use log::{error, info, debug};
+use std::io;
+use std::io::prelude::*;
+use uvm_core::platform::Platform;
+use uvm_core::unity::urls::IniUrlBuilder;
+use uvm_core::Version;
+use uvm_download_manifest::Options;
+use console::style;
+
+const USAGE: &str = "
+uvm-download-manifest - Download the manifest.ini file for a given unity version.
+
+Usage:
+  uvm-download-manifest [options] <version>
+  uvm-download-manifest (-h | --help)
+
+Options:
+  -o=PATH, --output-dir=PATH        the output path. default stdout
+  -n=NAME, --name=NAME              name of the output file. [default: unity-{version}-{platform}.ini]
+  -p=PLATFORM, --platform=PLATFORM  the platform to download (macos,win,linux). defaults to current platform.
+  -f, --force                       force override of existing files.
+  -v, --verbose                     print more output
+  -d, --debug                       print debug output
+  --color WHEN                      Coloring: auto, always, never [default: auto]
+  -h, --help                        show this help message and exit
+";
+
+fn main() {
+    run().unwrap_or_else(|err| {
+        error!("failed to download manifest");
+        error!("{}", err);
+    })
+}
+
+fn download_manifest<V, W>(version: V, platform: Platform, output: W) -> io::Result<()>
+where
+    V: AsRef<Version>,
+    W: Write,
+{
+    let url = IniUrlBuilder::new().platform(platform).build(version)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
+    info!("manifest URL: {}", url.as_str());
+    let response = reqwest::get(url.into_url())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
+
+    let mut buf_reader = io::BufReader::new(response);
+    let mut buf_writer = io::BufWriter::new(output);
+    let mut bytes:Vec<u8> = Vec::new();
+    buf_reader.read_to_end(&mut bytes)?;
+    buf_writer.write_all(&bytes)?;
+
+    eprintln!(
+        "{}",
+        style("Download complete").cyan(),
+    );
+    Ok(())
+}
+
+fn run() -> io::Result<()> {
+    let options: Options = uvm_cli::get_options(USAGE).unwrap();
+    debug!("{:?}", options);
+    info!(
+        "download manifest for version {} and platform {}",
+        options.version(),
+        options.platform()
+    );
+    let output_handle = options.output()?;
+    if let Some(output_path) = options.output_path() {
+        info!("write manifest to {}", output_path.display());
+    }
+    download_manifest(options.version(), options.platform(), output_handle)
+}

--- a/unity-2017.4.30f1-osx.ini
+++ b/unity-2017.4.30f1-osx.ini
@@ -1,0 +1,128 @@
+[Unity]
+title=Unity 2017.4.30f1
+description=Unity Editor
+url=MacEditorInstaller/Unity.pkg
+install=true
+mandatory=false
+size=761038875
+installedsize=2018568000
+version=2017.4.30f1
+md5=0d30cd64764cc7d5ce07771b2f4a290b
+[MonoDevelop]
+title=MonoDevelop / Unity Debugger
+description=MonoDevelop for Unity
+url=MacMonoDevelopInstaller/UnityMonoDevelop.pkg
+install=true
+mandatory=false
+size=97069079
+installedsize=304487000
+md5=399039fb6a141740439f144a1dd27c8e
+[Documentation]
+title=Documentation
+description=Unity User Manual and Scripting API Reference
+url=MacDocumentationInstaller/Documentation.pkg
+install=true
+mandatory=false
+size=263112728
+installedsize=511205000
+md5=acbb74ca97fb1bc716461fb92a04c7c1
+[StandardAssets]
+title=Standard Assets
+description=Unity Standard Assets for easily getting started building projects in Unity
+url=MacStandardAssetsInstaller/StandardAssets.pkg
+install=true
+mandatory=false
+size=189290528
+installedsize=184819000
+md5=83357499f41c6fb131cad1867adcce5e
+[Example]
+title=Example Project
+description=Unity Example Project based on Standard Assets
+url=MacExampleProjectInstaller/Examples.pkg
+install=false
+mandatory=false
+size=311961630
+installedsize=538830000
+md5=d8d01d0ea63384ea1be99e061a566c82
+[Android]
+title=Android Build Support
+description=Allows building your Unity projects for the Android platform
+url=MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=375179289
+installedsize=1136545000
+requires_unity=true
+md5=799539453a3279c88b0a7d145a684956
+[iOS]
+title=iOS Build Support
+description=Allows building your Unity projects for the iOS platform
+url=MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=1328887844
+installedsize=3049728000
+requires_unity=true
+md5=70e3bca2aad4aeb5138f0753d8393e91
+[AppleTV]
+title=tvOS Build Support
+description=Allows building your Unity projects for the AppleTV platform
+url=MacEditorTargetInstaller/UnitySetup-AppleTV-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=416040989
+installedsize=1018146000
+requires_unity=true
+md5=d87a4ba5c6f1555f4fa94e2fa58e86c3
+[Linux]
+title=Linux Build Support
+description=Allows building your Unity projects for the Linux platform
+url=MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=200914973
+installedsize=574274000
+requires_unity=true
+md5=9664aa069b3ba37b27fb409d4a83989b
+[Vuforia-AR]
+title=Vuforia Augmented Reality Support
+description=Allows building your Unity projects for the Vuforia-AR platform
+url=MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=70064146
+installedsize=125415000
+requires_unity=true
+md5=bd0d7ed9e7bba7001958898daffa77e6
+[WebGL]
+title=WebGL Build Support
+description=Allows building your Unity projects for the WebGL platform
+url=MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=228898844
+installedsize=626691000
+requires_unity=true
+md5=36900af6513b94d9dd355e4df0fbabfa
+[Windows]
+title=Windows Build Support
+description=Allows building your Unity projects for the Windows platform
+url=MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=336201769
+installedsize=1233710000
+requires_unity=true
+md5=36b724744be4ed2f9ffc39939ccb00ae
+[Facebook-Games]
+title=Facebook Gameroom Build Support
+description=Allows building your Unity projects for the Facebook-Games platform
+url=MacEditorTargetInstaller/UnitySetup-Facebook-Games-Support-for-Editor-2017.4.30f1.pkg
+install=false
+mandatory=false
+size=43423780
+installedsize=103945000
+requires_unity=true
+md5=90b59824bb4951bfbf99db3af85596b3
+optsync_webgl=WebGL
+optsync_windows=Windows

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -32,6 +32,7 @@ extern crate error_chain;
 pub mod utils;
 pub mod progress;
 pub mod sys;
+pub mod platform;
 
 #[macro_export]
 #[cfg(unix)]

--- a/uvm_core/src/platform.rs
+++ b/uvm_core/src/platform.rs
@@ -1,0 +1,116 @@
+use std::fmt::{self, Display};
+
+#[derive(Debug, Deserialize, Clone, Copy, Hash, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Platform {
+    #[serde(alias = "osx")]
+    MacOs,
+    Linux,
+    Win,
+}
+
+impl Platform {
+    pub fn current() -> Self {
+        if cfg!(windows) {
+            Platform::Win
+        } else if cfg!(target_os = "macos") {
+            Platform::MacOs
+        } else if cfg!(target_os = "linux") {
+            Platform::Linux
+        } else {
+            panic!("uvm doens't compile for this platform")
+        }
+    }
+}
+
+impl Display for Platform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Platform::MacOs => write!(f, "osx"),
+            Platform::Linux => write!(f, "linux"),
+            Platform::Win => write!(f, "win"),
+        }
+    }
+}
+
+impl Default for Platform {
+    fn default() -> Self {
+        Self::current()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_creates_sytem_default_platform() {
+        let system_platform = if cfg!(windows) {
+            Platform::Win
+        } else if cfg!(target_os = "macos") {
+            Platform::MacOs
+        } else if cfg!(target_os = "linux") {
+            Platform::Linux
+        } else {
+            panic!("uvm doens't compile for this platform")
+        };
+
+        assert_eq!(system_platform, Platform::default());
+    }
+
+    #[test]
+    fn can_be_printed_as_string() {
+        assert_eq!(&format!("{}",Platform::MacOs), "osx");
+        assert_eq!(&format!("{}",Platform::Win), "win");
+        assert_eq!(&format!("{}",Platform::Linux), "linux");
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct TestData {
+        field: Platform,
+    }
+
+    #[test]
+    fn macos_can_be_deserialized() {
+        let data = r#"
+        {
+            "field": "macos"
+        }"#;
+
+        let test:TestData = serde_json::from_str(data).unwrap();
+        assert_eq!(test.field, Platform::MacOs);
+    }
+
+    #[test]
+    fn win_can_be_deserialized() {
+        let data = r#"
+        {
+            "field": "win"
+        }"#;
+
+        let test:TestData = serde_json::from_str(data).unwrap();
+        assert_eq!(test.field, Platform::Win);
+    }
+
+    #[test]
+    fn linux_can_be_deserialized() {
+        let data = r#"
+        {
+            "field": "linux"
+        }"#;
+
+        let test:TestData = serde_json::from_str(data).unwrap();
+        assert_eq!(test.field, Platform::Linux);
+    }
+
+    #[test]
+    fn osx_can_be_deserialized() {
+        let data = r#"
+        {
+            "field": "osx"
+        }"#;
+
+        let test:TestData = serde_json::from_str(data).unwrap();
+        assert_eq!(test.field, Platform::MacOs);
+    }
+}

--- a/uvm_core/src/unity/urls.rs
+++ b/uvm_core/src/unity/urls.rs
@@ -1,8 +1,9 @@
 use crate::error::*;
+use crate::platform::Platform;
+use crate::unity::version::{Version, VersionType};
 use reqwest::Url;
 use std::convert::Into;
 use std::ops::Deref;
-use crate::unity::version::{Version, VersionType};
 
 const BASE_URL: &str = "https://download.unity3d.com/download_unity/";
 const BETA_BASE_URL: &str = "https://beta.unity3d.com/download/";
@@ -52,6 +53,37 @@ impl DownloadURL {
     }
 }
 
+pub struct IniUrlBuilder {
+    platform: Platform,
+}
+
+impl IniUrlBuilder {
+    pub fn new() -> Self {
+        Self {
+            platform: Platform::default(),
+        }
+    }
+
+    pub fn platform(&mut self, platform: Platform) -> &mut Self {
+        self.platform = platform;
+        self
+    }
+
+    pub fn build<V: AsRef<Version>>(&self, version: V) -> Result<IniUrl> {
+        let version = version.as_ref();
+        let download_url = DownloadURL::new(version)?;
+
+        let url = download_url
+            .join(&format!(
+                "unity-{}-{}.ini",
+                version.to_string(),
+                self.platform
+            ))
+            .map_err(|err| UvmError::with_chain(err, "failed to parse ini url"))?;
+        Ok(IniUrl(url))
+    }
+}
+
 #[derive(Debug)]
 pub struct IniUrl(Url);
 
@@ -72,21 +104,7 @@ impl Into<Url> for IniUrl {
 impl IniUrl {
     #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
     pub fn new<V: AsRef<Version>>(version: V) -> Result<IniUrl> {
-        let version = version.as_ref();
-        let download_url = DownloadURL::new(version)?;
-
-        let os = if cfg!(target_os = "macos") {
-            "osx"
-        } else if cfg!(target_os = "linux") {
-            "linux"
-        } else {
-            "win"
-        };
-
-        let url = download_url
-            .join(&format!("unity-{}-{}.ini", version.to_string(), os))
-            .map_err(|err| UvmError::with_chain(err, "failed to parse ini url"))?;
-        Ok(IniUrl(url))
+        IniUrlBuilder::new().build(version)
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
@@ -96,5 +114,54 @@ impl IniUrl {
 
     pub fn into_url(self) -> Url {
         self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ini_url_new_uses_default_platform() {
+        let v = Version::f(2017, 1, 1, 1);
+        let platform = Platform::default();
+        let url: IniUrl = IniUrl::new(&v).unwrap();
+
+        assert!(url
+            .to_string()
+            .as_str()
+            .contains(&format!("unity-{}-{}.ini", &v, platform)));
+    }
+
+    #[test]
+    fn ini_url_builder_uses_default_platform() {
+        let v = Version::f(2017, 1, 1, 1);
+        let platform = Platform::default();
+        let url: IniUrl = IniUrlBuilder::new().build(&v).unwrap();
+
+        assert!(url
+            .to_string()
+            .as_str()
+            .contains(&format!("unity-{}-{}.ini", &v, platform)));
+    }
+
+    fn get_test_platform() -> Platform {
+        match Platform::default() {
+            Platform::MacOs => Platform::Win,
+            Platform::Win => Platform::Linux,
+            Platform::Linux => Platform::MacOs,
+        }
+    }
+
+    #[test]
+    fn ini_url_builder_can_set_platform() {
+        let v = Version::f(2017, 1, 1, 1);
+        let platform = get_test_platform();
+        let url: IniUrl = IniUrlBuilder::new().platform(platform).build(&v).unwrap();
+
+        assert!(url
+            .to_string()
+            .as_str()
+            .contains(&format!("unity-{}-{}.ini", &v, platform)));
     }
 }


### PR DESCRIPTION
## Description

For testing purposes I created a small helper command to download a unity manifest by version and platform. I don't know how long this command will be here to stay and I don't see it as part of the API.

To configure the platform parameter on the `IniUrl` I created a new builder struct. By default the current system platform will be used. Before this was done with compile time checks. This has moved into the default implementation of the new enum `Platform`. The `IniUrlBuilder` can be used to set a different platform than the current system
platform.

## Changes

![ADD] ![NEW] auxiliary command `uvm-download-manifest`
![ADD] ![NEW] enum `Platform`
![IMPROVE] `unity::IniUrl` with new initializer `IniUrlBuilder`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
