### PR TITLE
Add uvm-modules command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2022,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm-modules"
+version = "0.1.0"
+dependencies = [
+ "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flexi_logger 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_cli 2.0.1",
+ "uvm_core 0.3.1",
+]
+
+[[package]]
 name = "uvm-uninstall"
 version = "2.1.0"
 dependencies = [
@@ -2275,6 +2298,7 @@ dependencies = [
 "checksum indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install-uvm: target/release/uvm
 	install -m755 -- target/release/uvm-uninstall "$(DESTDIR)$(PREFIX)/bin/"
 	install -m755 -- target/release/uvm-versions "$(DESTDIR)$(PREFIX)/bin/"
 	install -m755 -- target/release/uvm-commands "$(DESTDIR)$(PREFIX)/bin/"
+	install -m755 -- target/release/uvm-modules "$(DESTDIR)$(PREFIX)/bin/"
 	install -m755 -- target/release/uvm "$(DESTDIR)$(PREFIX)/bin/"
 
 test: target/release/uvm

--- a/install/uvm-modules/Cargo.toml
+++ b/install/uvm-modules/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uvm-modules"
+version = "0.1.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+edition = "2018"
+[dependencies]
+flexi_logger = "0.9.2"
+indicatif = "0.11.0"
+log = "0.4.5"
+console = "0.6.1"
+serde = "1.0"
+serde_derive = "1.0"
+uvm_cli = { path = "../../uvm_cli" }
+uvm_core = { path = "../../uvm_core" }
+itertools = "0.8.0"

--- a/install/uvm-modules/src/lib.rs
+++ b/install/uvm-modules/src/lib.rs
@@ -1,0 +1,44 @@
+use serde::Deserialize;
+use uvm_core::Version;
+use uvm_core::error::*;
+use uvm_core::unity::{Installations, Manifest, Modules, Category};
+use uvm_cli::ColorOption;
+#[derive(Debug, Deserialize)]
+pub struct Options {
+    arg_version: Version,
+    flag_category: Option<Vec<Category>>,
+    flag_verbose: bool,
+    flag_debug: bool,
+    flag_color: ColorOption,
+}
+
+impl Options {
+    pub fn version(&self) -> &Version {
+        &self.arg_version
+    }
+
+    pub fn category(&self) -> Option<&Vec<Category>> {
+        self.flag_category.as_ref()
+    }
+}
+
+impl uvm_cli::Options for Options {
+    fn verbose(&self) -> bool {
+        self.flag_verbose
+    }
+
+    fn debug(&self) -> bool {
+        self.flag_debug
+    }
+
+    fn color(&self) -> &ColorOption {
+        &self.flag_color
+    }
+}
+
+pub fn load_modules<V: AsRef<Version>>(version:V) -> Result<Modules> {
+    let version = version.as_ref();
+    let manifest = Manifest::load(version)?;
+    let modules:Modules = manifest.into();
+    Ok(modules)
+}

--- a/install/uvm-modules/src/main.rs
+++ b/install/uvm-modules/src/main.rs
@@ -1,0 +1,80 @@
+use console::Style;
+use itertools::Itertools;
+use log::error;
+use uvm_cli::Options;
+use uvm_core::error::Result;
+use uvm_core::unity::Module;
+use uvm_modules;
+use uvm_core::unity::Category;
+
+const USAGE: &str = "
+uvm-modules - List available modules for a specified unity version.
+
+Usage:
+  uvm-modules [options] [--category=CATEGORY...] <version>
+  uvm-modules (-h | --help)
+
+Options:
+  -c=CATEGORY, --category=CATEGORY    filter by category
+  -v, --verbose                       print more output
+  -d, --debug                         print debug output
+  --color WHEN                        Coloring: auto, always, never [default: auto]
+  -h, --help                          show this help message and exit
+
+Arguments:
+  <version>              The unity version to list modules for in the form of `2018.1.0f3`
+";
+
+fn main() {
+    list_modules().unwrap_or_else(|err| {
+        error!("failed to list modules");
+        error!("{}", err);
+    })
+}
+
+fn list_modules() -> Result<()> {
+    let options: uvm_modules::Options = uvm_cli::get_options(USAGE)?;
+    let modules = uvm_modules::load_modules(options.version())?;
+
+    if options.debug() {
+        println!("{:?}", options);
+    }
+
+    let modules: Vec<Module> = modules
+        .into_iter()
+        .filter(|m| m.parent.is_none() && m.sync.is_none())
+        .filter(|m| {
+            if let Some(c) = options.category() {
+                c.contains(&m.category)
+            } else {
+                true
+            }
+        })
+        .sorted_by(|m_1, m_2| Ord::cmp(&m_1.category, &m_2.category))
+        .collect();
+
+    let category_style = Style::new().white().bold();
+    let out_style = Style::new().cyan();
+    let path_style = Style::new().italic().green();
+
+    let mut category:Option<Category> = None;
+    for (i,module) in modules.into_iter().enumerate() {
+        if options.verbose() {
+            if category.is_none() || module.category != category.unwrap() {
+                category = Some(module.category);
+                if i != 0 {
+                    println!("");
+                }
+                println!("{}:", category_style.apply_to(module.category.to_string()));
+            }
+            println!(
+                "{} - {}",
+                out_style.apply_to(module.id),
+                path_style.apply_to(module.description)
+            );
+        } else {
+            println!("{}", out_style.apply_to(module.id));
+        }
+    }
+    Ok(())
+}

--- a/uvm_core/src/unity/component/category.rs
+++ b/uvm_core/src/unity/component/category.rs
@@ -1,0 +1,70 @@
+use super::error::{ParseComponentError, ParseComponentErrorKind};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+use Category::*;
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+pub enum Category {
+    DevTools,
+    Plugins,
+    Documentation,
+    Components,
+    Platforms,
+    LanguagePack,
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            DevTools => "Dev tools",
+            Plugins => "Plugins",
+            Documentation => "Documentation",
+            Components => "Components",
+            Platforms => "Platforms",
+            LanguagePack => "Language packs (Preview)",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl Default for Category {
+    fn default() -> Self {
+        Platforms
+    }
+}
+
+impl FromStr for Category {
+    type Err = ParseComponentError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DevTools" | "Dev tools" => Ok(DevTools),
+            "Plugins" => Ok(Plugins),
+            "Documentation" => Ok(Documentation),
+            "Components" => Ok(Components),
+            "Platforms" => Ok(Platforms),
+            "LanguagePack" | "Language packs (Preview)" => Ok(LanguagePack),
+            x => Err(ParseComponentErrorKind::UnsupportedCategory(x.to_string()).into()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Category {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Category::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for Category {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}

--- a/uvm_core/src/unity/component/error.rs
+++ b/uvm_core/src/unity/component/error.rs
@@ -8,5 +8,10 @@ error_chain! {
             description("unsupported component"),
             display("unsupported component: '{}'", t),
         }
+
+        UnsupportedCategory(t: String) {
+            description("unsupported component category"),
+            display("unsupported component category: '{}'", t),
+        }
     }
 }

--- a/uvm_core/src/unity/component/mod.rs
+++ b/uvm_core/src/unity/component/mod.rs
@@ -8,6 +8,9 @@ use std::slice::Iter;
 use std::str::FromStr;
 use reqwest::Url;
 mod error;
+mod category;
+
+pub use self::category::Category;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Deserialize, Serialize)]
 pub enum Component {
@@ -201,26 +204,24 @@ impl Component {
             .unwrap_or(false)
     }
 
-    pub fn category<V: AsRef<Version>>(self, version: V) -> String {
-        let c = match self {
-            MonoDevelop | VisualStudio => "Dev tools",
-            Mono | FacebookGameRoom => "Plugins",
+    pub fn category<V: AsRef<Version>>(self, version: V) -> Category {
+        match self {
+            MonoDevelop | VisualStudio => Category::DevTools,
+            Mono | FacebookGameRoom => Category::Plugins,
             #[cfg(windows)]
             VisualStudioProfessionalUnityWorkload | VisualStudioEnterpriseUnityWorkload => {
-                "Plugins"
+                Category::Plugins
             }
             Documentation | StandardAssets | ExampleProject | Example => {
                 if *version.as_ref() >= Version::a(2018, 2, 0, 0) {
-                    "Documentation"
+                    Category::Documentation
                 } else {
-                    "Components"
+                    Category::Components
                 }
             }
-            Language(_) => "Language packs (Preview)",
-            _ => "Platforms",
-        };
-
-        c.to_string()
+            Language(_) => Category::LanguagePack,
+            _ => Category::Platforms,
+        }
     }
 
     pub fn sync(self) -> Option<String> {

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -8,6 +8,7 @@ mod localization;
 
 use core::iter::FromIterator;
 pub use self::component::Component;
+pub use self::component::Category;
 pub use self::localization::Localization;
 pub use self::current_installation::current_installation;
 pub use self::current_installation::CurrentInstallation;

--- a/uvm_core/src/unity/version/module.rs
+++ b/uvm_core/src/unity/version/module.rs
@@ -8,6 +8,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::str::FromStr;
+use crate::unity::component::Category;
 
 #[derive(Serialize, Deserialize, Debug, Default, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -20,7 +21,7 @@ pub struct Module {
     pub name: String,
     pub description: String,
     pub download_url: String,
-    pub category: String,
+    pub category: Category,
     pub installed_size: u64,
     pub download_size: u64,
     pub visible: bool,


### PR DESCRIPTION
## Description

As a preparation for changes in the command line interface of the install command, I added this new helper command `uvm-modules` which lists available modules for the given versions.

```
uvm-modules - List available modules for a specified unity version.

Usage:
  uvm-modules [options] [--category=CATEGORY...] <version>
  uvm-modules (-h | --help)

Options:
  -c=CATEGORY, --category=CATEGORY    filter by category
  -v, --verbose                       print more output
  -d, --debug                         print debug output
  --color WHEN                        Coloring: auto, always, never [default: auto]
  -h, --help                          show this help message and exit

Arguments:
  <version>              The unity version to list modules for in the form of `2018.1.0f3`
```

The command is quite slow at the moment because no caching is involved.

To allow the category filtering I created a new enum `unity::Category`.
This enum is also used on the modules generation logic.

## Changes

![ADD] ![NEW] command `uvm-modules`
![ADD] enum `unity::component::Category`
![IMPROVE] module generation with new `Category` enum

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"