### PR TITLE
Fix ndk version for unity 2019.3

### DIFF
--- a/commands/uvm-generate-modules-json/tests/fixures/linux/v2019/2019.3.0a8_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/linux/v2019/2019.3.0a8_modules.json
@@ -138,8 +138,8 @@
   {
     "id": "android-ndk",
     "name": "Android NDK",
-    "description": "Android NDK r19b",
-    "downloadUrl": "https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip",
+    "description": "Android NDK r19",
+    "downloadUrl": "https://dl.google.com/android/repository/android-ndk-r19-linux-x86_64.zip",
     "category": "Platforms",
     "installedSize": 2690000000,
     "downloadSize": 785000000,

--- a/commands/uvm-generate-modules-json/tests/fixures/mac/v2019/2019.3.0a8_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/mac/v2019/2019.3.0a8_modules.json
@@ -16,8 +16,8 @@
     "id": "android-ndk",
     "sync": "android-sdk-ndk-tools",
     "name": "Android NDK",
-    "description": "Android NDK r19b",
-    "downloadUrl": "https://dl.google.com/android/repository/android-ndk-r19b-darwin-x86_64.zip",
+    "description": "Android NDK r19",
+    "downloadUrl": "https://dl.google.com/android/repository/android-ndk-r19-darwin-x86_64.zip",
     "category": "Platforms",
     "installedSize": 2700000000,
     "downloadSize": 770000000,
@@ -25,7 +25,7 @@
     "selected": false,
     "destination": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/NDK",
     "renameTo": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/NDK",
-    "renameFrom": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/NDK/android-ndk-r19b"
+    "renameFrom": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/NDK/android-ndk-r19"
   },
   {
     "id": "android-sdk-ndk-tools",

--- a/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.3.0a8_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.3.0a8_modules.json
@@ -15,8 +15,8 @@
     "id": "android-ndk",
     "sync": "android-sdk-ndk-tools",
     "name": "Android NDK",
-    "description": "Android NDK r19b",
-    "downloadUrl": "https://dl.google.com/android/repository/android-ndk-r19b-windows-x86_64.zip",
+    "description": "Android NDK r19",
+    "downloadUrl": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip",
     "category": "Platforms",
     "installedSize": 2510000000,
     "downloadSize": 759000000,
@@ -24,7 +24,7 @@
     "selected": false,
     "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK",
-    "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK/android-ndk-r19b"
+    "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK/android-ndk-r19"
   },
   {
     "id": "android-sdk-ndk-tools",

--- a/uvm_core/src/sys/linux/unity/version/module.rs
+++ b/uvm_core/src/sys/linux/unity/version/module.rs
@@ -30,7 +30,7 @@ pub fn get_android_open_jdk_download_info<V: AsRef<Version>>(_version:V) -> Modu
 pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<ModulePart> {
     let version = version.as_ref();
     let (ndk_version, ndk_install_size, ndk_download_size) = if *version >= Version::a(2019,3,0,0) {
-        ("r19b", 2_690_000_000, 785_000_000)
+        ("r19", 2_690_000_000, 785_000_000)
     } else {
         ("r16b", 2_355_200_000, 626_000_000)
     };

--- a/uvm_core/src/sys/mac/unity/version/module.rs
+++ b/uvm_core/src/sys/mac/unity/version/module.rs
@@ -30,7 +30,7 @@ pub fn get_android_open_jdk_download_info<V: AsRef<Version>>(_version:V) -> Modu
 pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<ModulePart> {
     let version = version.as_ref();
     let ndk_version = if *version >= Version::a(2019,3,0,0) {
-        "r19b"
+        "r19"
     } else {
         "r16b"
     };

--- a/uvm_core/src/sys/win/unity/version/module.rs
+++ b/uvm_core/src/sys/win/unity/version/module.rs
@@ -30,7 +30,7 @@ pub fn get_android_open_jdk_download_info<V: AsRef<Version>>(_version:V) -> Modu
 pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<ModulePart> {
     let version = version.as_ref();
     let (ndk_version, ndk_install_size, ndk_download_size) = if *version >= Version::a(2019,3,0,0) {
-        ("r19b", 2_510_000_000, 759_000_000)
+        ("r19", 2_510_000_000, 759_000_000)
     } else {
         ("r16b", 2_355_200_000, 626_000_000)
     };


### PR DESCRIPTION
## Description

I picked `r19b` for the ndk version because this was what the https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json file told me at one point. This seems to be an error since Unity complains about this version. This fix simply reverts to `r19`.

## Changes

![FIX] ndk version for unity 2019.3

[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
