### PR TITLE
Fix generate modules json command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm-fix-modules-json"
+version = "1.0.0"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flexi_logger 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_cli 2.0.1",
+ "uvm_core 0.3.1",
+]
+
+[[package]]
 name = "uvm-generate-modules-json"
 version = "1.0.0"
 dependencies = [

--- a/commands/uvm-fix-modules-json/Cargo.toml
+++ b/commands/uvm-fix-modules-json/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uvm-fix-modules-json"
+version = "1.0.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+edition = "2018"
+[dependencies]
+cfg-if = "0.1.9"
+flexi_logger = "0.9.2"
+indicatif = "0.11.0"
+log = "0.4.5"
+console = "0.6.1"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0.40"
+lazy_static = "1.3.0"
+uvm_cli = { path = "../../uvm_cli" }
+uvm_core = { path = "../../uvm_core" }
+[dev-dependencies]
+stringreader = "0.1.1"

--- a/commands/uvm-fix-modules-json/src/lib.rs
+++ b/commands/uvm-fix-modules-json/src/lib.rs
@@ -1,0 +1,42 @@
+use serde_derive::Deserialize;
+use uvm_cli;
+use uvm_cli::ColorOption;
+use uvm_core::unity::Version;
+
+#[derive(Debug, Deserialize)]
+pub struct Options {
+    arg_version: Option<Vec<Version>>,
+    flag_verbose: bool,
+    flag_debug: bool,
+    flag_all: bool,
+    flag_dry_run: bool,
+    flag_color: ColorOption,
+}
+
+impl Options {
+    pub fn version(&self) -> &Option<Vec<Version>> {
+        &self.arg_version
+    }
+
+    pub fn all(&self) -> bool {
+        self.flag_all
+    }
+
+    pub fn dry_run(&self) -> bool {
+        self.flag_dry_run
+    }
+}
+
+impl uvm_cli::Options for Options {
+    fn verbose(&self) -> bool {
+        self.flag_verbose
+    }
+
+    fn debug(&self) -> bool {
+        self.flag_debug
+    }
+
+    fn color(&self) -> &ColorOption {
+        &self.flag_color
+    }
+}

--- a/commands/uvm-fix-modules-json/src/main.rs
+++ b/commands/uvm-fix-modules-json/src/main.rs
@@ -1,0 +1,85 @@
+use console::style;
+use log::{debug, info, trace};
+use std::fs::OpenOptions;
+use std::io::{Result, Write};
+use std::process;
+use uvm_cli;
+use uvm_core;
+use uvm_core::unity::{Installations, Manifest, Modules, ModulesMap};
+use uvm_fix_modules_json::Options;
+
+const USAGE: &str = "
+uvm-fix-modules-json - Write the modules.json for the given unity version.
+
+Usage:
+  uvm-fix-modules-json [options] (--all | <version>...)
+  uvm-fix-modules-json (-h | --help)
+
+Options:
+  --dry-run                         only prints modules to stdout
+  --all                             generate modules.json for all installed editors
+  -v, --verbose                     print more output
+  -d, --debug                       print debug output
+  --color WHEN                      Coloring: auto, always, never [default: auto]
+  -h, --help                        show this help message and exit
+";
+
+fn generate_for_installation(options: Options) -> Result<()> {
+    let installations = if options.all() {
+        info!("generate modules.json for all installations");
+        uvm_core::list_all_installations()
+    } else {
+        let v = options
+            .version()
+            .as_ref()
+            .expect("expect a provided version");
+        let installations: Installations = v
+            .iter()
+            .flat_map(|v| uvm_core::find_installation(v).into_iter())
+            .collect();
+        Ok(installations)
+    }
+    .unwrap();
+
+    for i in installations {
+        info!("{}", style(format!("generate modules.json for installation: {}", i.path().display())).yellow());
+        let manifest = Manifest::load(i.version()).expect("a manifest");
+        let c = i.installed_components();
+        let modules: Modules = manifest.into();
+        let mut modules: ModulesMap = modules.into();
+        modules.mark_installed_modules(c);
+        let modules: Modules = modules.into();
+        let j = serde_json::to_string_pretty(&modules).expect("export json");
+        let output_path = i.path().join("modules.json");
+        if options.dry_run() {
+            eprintln!("modules json for {}", &i.version());
+            eprintln!("output path: {}", output_path.display());
+            println!("{}", j);
+        } else {
+            info!("{}", style(format!("write {}", output_path.display())).green());
+            let output_path = i.path().join("modules.json");
+            let mut f = OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .create(true)
+                .open(output_path)?;
+            write!(f, "{}", j)?;
+            trace!("{}", j);
+        }
+    }
+    Ok(())
+}
+
+fn main() {
+    let options: Options = uvm_cli::get_options(USAGE).unwrap();
+    trace!("generate modules.json");
+
+    generate_for_installation(options).unwrap_or_else(|err| {
+        let message = "Unable generate modules.json";
+        eprintln!("{}", style(message).red());
+        eprintln!("{}", style(err).red());
+        process::exit(1);
+    });
+
+    eprintln!("{}", style("Done").green());
+}

--- a/commands/uvm-generate-modules-json/src/lib.rs
+++ b/commands/uvm-generate-modules-json/src/lib.rs
@@ -1,24 +1,88 @@
+use std::path::PathBuf;
+use std::fs::File;
 use serde_derive::Deserialize;
 use uvm_cli;
 use uvm_cli::ColorOption;
 use uvm_core::unity::Version;
+use std::io::{self, Write};
 
 #[derive(Debug, Deserialize)]
 pub struct Options {
-    arg_version: Option<Version>,
+    arg_version: Vec<Version>,
+    #[serde(default)]
+    flag_output_dir: Option<PathBuf>,
+    flag_name: String,
     flag_verbose: bool,
+    flag_force: bool,
     flag_debug: bool,
-    flag_all: bool,
     flag_color: ColorOption,
 }
 
+pub enum Output {
+    File(File),
+    Stdout,
+}
+
+impl Default for Output {
+    fn default() -> Self {
+        Output::Stdout
+    }
+}
+
+impl Write for Output {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        use Output::*;
+        match self {
+            File(x) => x.write(buf),
+            _ => console::Term::stdout().write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        use Output::*;
+        match self {
+            File(x) => x.flush(),
+            _ => console::Term::stdout().flush(),
+        }
+    }
+}
+
 impl Options {
-    pub fn version(&self) -> &Option<Version> {
+    pub fn version(&self) -> &Vec<Version> {
         &self.arg_version
     }
 
-    pub fn all(&self) -> bool {
-        self.flag_all
+    pub fn name<V: AsRef<Version>>(&self, version:V) -> String {
+        let name = &self.flag_name;
+        let version = version.as_ref();
+        name.as_str().replace("{version}", &version.to_string())
+    }
+
+    pub fn output<V: AsRef<Version>>(&self, version:V) -> io::Result<impl Write> {
+        use std::fs::OpenOptions;
+        if let Some(path) = &self.flag_output_dir {
+            if !path.is_dir() {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, "output path is not a directory"))
+            } else {
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .create_new(!self.flag_force)
+                    .open(path.join(self.name(version)))
+                    .and_then(|f| Ok(Output::File(f)))
+            }
+        } else {
+            Ok(Output::default())
+        }
+    }
+
+    pub fn output_path<V: AsRef<Version>>(&self, version:V) -> Option<PathBuf> {
+        let path = self.flag_output_dir.as_ref()?;
+        if !path.is_dir() {
+            None
+        } else {
+            Some(path.join(self.name(version)))
+        }
     }
 }
 

--- a/uvm_core/src/unity/component/mod.rs
+++ b/uvm_core/src/unity/component/mod.rs
@@ -194,11 +194,13 @@ impl Component {
     }
 
     pub fn is_installed<P: AsRef<Path>>(self, unity_install_location: P) -> bool {
-        let unity_install_location = unity_install_location.as_ref();
-        self.install_location()
-            .map(|install_path| unity_install_location.join(install_path))
-            .map(|install_path| install_path.exists())
-            .unwrap_or(false)
+        if let Some(install_path) = self.install_location() {
+            let unity_install_location = unity_install_location.as_ref();
+            let install_path = unity_install_location.join(install_path);
+            install_path.exists()
+        } else {
+            false
+        }
     }
 
     pub fn category<V: AsRef<Version>>(self, version: V) -> String {

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -17,8 +17,7 @@ pub use self::version::manifest::Manifest;
 pub use self::version::manifest::ManifestIteratorItem;
 pub use self::version::manifest::MD5;
 pub use self::version::manifest::ComponentData;
-pub use self::version::module::Module;
-pub use self::version::module::Modules;
+pub use self::version::module::{Module, Modules, ModulesMap};
 pub use self::version::Version;
 pub use self::version::VersionType;
 pub use self::version::{UvmVersionError, UvmVersionErrorKind, ResultExt as UvmVersionErrorResultExt, Result as UvmVersionErrorResult};
@@ -105,7 +104,7 @@ impl Iterator for InstalledComponents {
                 trace!(
                     "found component {:?} installed at {}",
                     &c,
-                    &self.installation.path().display()
+                    &c.install_location().unwrap().display()
                 );
                 return Some(*c);
             }

--- a/uvm_core/src/unity/version/module.rs
+++ b/uvm_core/src/unity/version/module.rs
@@ -2,6 +2,7 @@ use crate::sys::unity::version::module::get_android_open_jdk_download_info;
 use crate::sys::unity::version::module::get_android_sdk_ndk_download_info;
 use crate::unity::{VersionType, Component, Manifest, ManifestIteratorItem, Localization};
 use crate::unity::MD5;
+use crate::unity::InstalledComponents;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -263,6 +264,16 @@ impl From<Manifest<'_>> for Modules {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ModulesMap(HashMap<Component, Module>);
+
+impl ModulesMap {
+    pub fn mark_installed_modules(&mut self, components:InstalledComponents) {
+        for component in components {
+            if let Some(m) = self.0.get_mut(&component) {
+                m.selected = true;
+            }
+        }
+    }
+}
 
 impl Deref for Modules {
     type Target = Vec<Module>;


### PR DESCRIPTION
## Description

The first version of the command missed the desired usage. So I split the command into two.

- `generate-modules-json`
- `fix-modules-json`

The use case for the `fix-modules-json` command is the actual initial idea for the `generate-modules-json` command which got lost during implementation. This new command reads the given version to generate/update the `modules.json` file for. In contrast to the original implementation, it marks modules in the file as selected when they are installed.

The `generate-modules-json` command was changed to mimic the behavior of `download-manifest`. It is possible to generate a `modules.json` file for any valid Unity version. The term `generate` is important as this file is still created at runtime and not fetched from any remote or local location.

addresses: #31 

## Changes

![FIX] `generate-modules-json` command
![ADD] `fix-modules-json` command

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
