### PR TITLE
Fix linux-mono component installation path

### DIFF
--- a/commands/uvm-generate-modules-json/tests/fixures/mac/v2019/2019.3.0a8_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/mac/v2019/2019.3.0a8_modules.json
@@ -109,7 +109,7 @@
     "downloadSize": 85452817,
     "visible": true,
     "selected": false,
-    "destination": "{UNITY_PATH}",
+    "destination": "{UNITY_PATH}/PlaybackEngines/LinuxStandaloneSupport",
     "checksum": "53c051ef052e7351d5fab6b55e2ad82c"
   },
   {

--- a/uvm_core/src/sys/mac/unity/component.rs
+++ b/uvm_core/src/sys/mac/unity/component.rs
@@ -5,7 +5,7 @@ pub fn installpath(component:Component) -> Option<PathBuf> {
     use Component::*;
     let path = match component {
         Mono | VisualStudio | FacebookGameRoom => None,
-        MonoDevelop | Documentation | LinuxMono => Some(""),
+        MonoDevelop | Documentation => Some(""),
         StandardAssets => Some("Standard Assets"),
         ExampleProject | Example => Some("/Users/Shared/Unity"),
         Android => Some("PlaybackEngines/AndroidPlayer"),
@@ -17,7 +17,7 @@ pub fn installpath(component:Component) -> Option<PathBuf> {
         Ios => Some("PlaybackEngines/iOSSupport"),
         TvOs => Some("PlaybackEngines/AppleTVSupport"),
         AppleTV => Some("PlaybackEngines/AppleTVSupport"),
-        Linux  => Some("PlaybackEngines/LinuxStandaloneSupport"),
+        Linux | LinuxMono => Some("PlaybackEngines/LinuxStandaloneSupport"),
         Mac | MacIL2CPP => Some("Unity.app/Contents/PlaybackEngines/MacStandaloneSupport"),
         Samsungtv | SamsungTV => Some("PlaybackEngines/STVPlayer"),
         Tizen => Some("PlaybackEngines/TizenPlayer"),

--- a/uvm_core/src/sys/win/unity/component.rs
+++ b/uvm_core/src/sys/win/unity/component.rs
@@ -32,7 +32,7 @@ pub fn install_location(component:Component) -> Option<PathBuf> {
     use Component::*;
     let path = match component {
         VisualStudio | ExampleProject | Example | FacebookGameRoom | VisualStudioProfessionalUnityWorkload | VisualStudioEnterpriseUnityWorkload => None,
-        Mono | MonoDevelop | LinuxMono => Some(r""),
+        Mono | MonoDevelop => Some(r""),
         Documentation => Some(r"Editor\Data"),
         StandardAssets => Some(r"Editor"),
         Android => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer"),
@@ -43,7 +43,7 @@ pub fn install_location(component:Component) -> Option<PathBuf> {
         AndroidOpenJdk => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\OpenJDK"),
         Ios => Some(r"Editor\Data\PlaybackEngines\iOSSupport"),
         TvOs | AppleTV => Some(r"Editor\Data\PlaybackEngines\AppleTVSupport"),
-        Linux => Some(r"Editor\Data\PlaybackEngines\LinuxStandaloneSupport"),
+        Linux | LinuxMono => Some(r"Editor\Data\PlaybackEngines\LinuxStandaloneSupport"),
         Mac | MacIL2CPP | MacMono => Some(r"Editor\Data\PlaybackEngines\MacStandaloneSupport"),
         Metro | UwpIL2CPP | UwpNet | UniversalWindowsPlatform => Some(r"Editor\Data\PlaybackEngines\MetroSupport"),
         Samsungtv | SamsungTV => Some(r"Editor\Data\PlaybackEngines\STVPlayer"),


### PR DESCRIPTION
## Description

During development I saw a discrepancy with the `linux-mono` installation path reported by Unity Hub on macOS. Normally all Unity published components use installers that exactly know where it should be installed into. The official `modules.json` states `$UNITY_PATH` for this new module. I tried installing it via Unity Hub and found and it didn't work. After moving the installed items into `PlaybackEngines\LinuxStandaloneSupport` I was able to use the component from within Unity. I opened a [bug report] to make Unity aware of this issue.

Since I'm fairly certain that this is a bug and keeping a reference implantation with Unity Hub would result in non working installation I decided to update my `modules.json` generator logic and patch it right away.

## Changes

![FIX] linux-mono component installation path

[bug report]: https://fogbugz.unity3d.com/default.asp?1187040_pjad4akj8jomc6q2

[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"