### PR TITLE
Improve unity::Module struct by using unity::Component as id

### DIFF
--- a/uvm_core/src/unity/component/mod.rs
+++ b/uvm_core/src/unity/component/mod.rs
@@ -264,6 +264,12 @@ impl Component {
     }
 }
 
+impl Default for Component {
+    fn default() -> Self {
+        Component::Editor
+    }
+}
+
 impl fmt::Display for Component {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
## Description

The internal data structures got a little bit shaken when introducing the support of the Unity Hub modules. The future plan is to use the `Module` struct as the single point of truth and only rely on the ini Manifests when needed. The `Module` struct is in some way a superset of the `Manifest` hash map but is implemented in a way that makes some hard choices when reading and comparing between the two. One issue early on was the `id` field of the `Module`. This field is actually a different `string` representation of `Component` I choose not to use the `Component` enum directly in the beginning concentrate on the actual generator code. The `Component` enum is serialize able with `serde` but all field annoation match the names and settings for the `Manifest` ini representation. So I left it as a `String` value for the time being.

This patch changes this. As a quick fix for the serialization issue I created a custom serialize module and instruct `serde` to use this instead of the default one. I route the serialize calls to `Componente::to_string` and the deserialize to `Component::from_str`. I don't know the performance impact but for the time being this works. In the future the `Component` enum will serialize directly to the `Module` naming pattern and I will find a different solution for the
`Manifest`.

## Changes

![IMPROVE] `unity::Module` struct by using `unity::Component` as `id`

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"