### PR TITLE
Improve module struct layout

### DIFF
--- a/uvm_core/src/unity/component/mod.rs
+++ b/uvm_core/src/unity/component/mod.rs
@@ -226,14 +226,13 @@ impl Component {
         }
     }
 
-    pub fn sync(self) -> Option<String> {
-        let s = match self {
-            Mono => Some("visualstudio"),
-            AndroidSdkNdkTools | AndroidOpenJdk => Some("Android Build Support"),
-            AndroidSdkBuildTools | AndroidSdkPlatformTools | AndroidSdkPlatforms | AndroidNdk => Some("android-sdk-ndk-tools"),
+    pub fn sync(self) -> Option<Component> {
+        match self {
+            Mono => Some(VisualStudio),
+            AndroidSdkNdkTools | AndroidOpenJdk => Some(Android),
+            AndroidSdkBuildTools | AndroidSdkPlatformTools | AndroidSdkPlatforms | AndroidNdk => Some(AndroidSdkNdkTools),
             _ => None,
-        };
-        s.map(|s| s.to_string())
+        }
     }
 
     fn add_version_to_url<V:AsRef<Version>>(self, download_url:&str, version:V) -> String {


### PR DESCRIPTION
## Description

To make it esier in the future to map and connect different modules which are linked with the `parent` or `sync` field, we need to use the same types for module `id`, `sync` and `parent`. This patch does this in a crude way. I had some problems getting `serde` to emit the correct code so that I can also serialize/deserialize `Option<Component>` types.

One noteworthy point is the fact that Unity serializes the `android` component as `Android Build Support`, but only for the `sync` field. I kept this error because I have no idea at the moment if Unity Hub works if the value would be encoded correctly with `android`.

## Changes

![IMPROVE] `Module` struct layout

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"