### PR TITLE
Improve modules listing

### DIFF
--- a/install/uvm-modules/src/main.rs
+++ b/install/uvm-modules/src/main.rs
@@ -3,9 +3,8 @@ use itertools::Itertools;
 use log::error;
 use uvm_cli::Options;
 use uvm_core::error::Result;
-use uvm_core::unity::Module;
-use uvm_modules;
 use uvm_core::unity::Category;
+use uvm_modules;
 
 const USAGE: &str = "
 uvm-modules - List available modules for a specified unity version.
@@ -16,13 +15,15 @@ Usage:
 
 Options:
   -c=CATEGORY, --category=CATEGORY    filter by category
+  -s, --show-sync-modules             list also sync modules
+  -a, --all                           list also invisible modules
   -v, --verbose                       print more output
   -d, --debug                         print debug output
   --color WHEN                        Coloring: auto, always, never [default: auto]
   -h, --help                          show this help message and exit
 
 Arguments:
-  <version>              The unity version to list modules for in the form of `2018.1.0f3`
+  <version>                           The unity version to list modules for in the form of `2018.1.0f3`
 ";
 
 fn main() {
@@ -40,9 +41,9 @@ fn list_modules() -> Result<()> {
         println!("{:?}", options);
     }
 
-    let modules: Vec<Module> = modules
-        .into_iter()
-        .filter(|m| m.parent.is_none() && m.sync.is_none())
+    let modules = modules
+        .iter()
+        .filter(|m| options.all() || m.visible)
         .filter(|m| {
             if let Some(c) = options.category() {
                 c.contains(&m.category)
@@ -50,31 +51,64 @@ fn list_modules() -> Result<()> {
                 true
             }
         })
-        .sorted_by(|m_1, m_2| Ord::cmp(&m_1.category, &m_2.category))
-        .collect();
+        .sorted_by(|m_1, m_2| match Ord::cmp(&m_1.category, &m_2.category) {
+            std::cmp::Ordering::Equal => Ord::cmp(&m_1.id.to_string(), &m_2.id.to_string()),
+            x => x,
+        })
+        .map(|m| uvm_modules::Module::new(m, &modules))
+        .filter(|m| m.parent.is_none() && m.sync.is_none());
 
     let category_style = Style::new().white().bold();
     let out_style = Style::new().cyan();
     let path_style = Style::new().italic().green();
 
-    let mut category:Option<Category> = None;
-    for (i,module) in modules.into_iter().enumerate() {
-        if options.verbose() {
-            if category.is_none() || module.category != category.unwrap() {
-                category = Some(module.category);
-                if i != 0 {
-                    println!("");
-                }
-                println!("{}:", category_style.apply_to(module.category.to_string()));
+    let mut category: Option<Category> = None;
+    for (i, module) in modules.enumerate() {
+        if options.verbose() && (category.is_none() || module.category != category.unwrap()) {
+            category = Some(module.category);
+            if i != 0 {
+                println!();
             }
-            println!(
-                "{} - {}",
-                out_style.apply_to(module.id),
-                path_style.apply_to(module.description)
-            );
-        } else {
-            println!("{}", out_style.apply_to(module.id));
+            println!("{}:", category_style.apply_to(module.category.to_string()));
         }
+
+        print_module(&module, "", 0, options.verbose(), &out_style, &path_style, &options);
     }
     Ok(())
+}
+
+fn print_module(
+    module: &uvm_modules::Module<'_>,
+    prefix: &str,
+    rjust: usize,
+    verbose: bool,
+    out_style: &Style,
+    path_style: &Style,
+    options: &uvm_modules::Options
+) {
+    let p_prefix = console::pad_str(prefix, rjust, console::Alignment::Right, None);
+    if verbose {
+        println!(
+            "{}{} - {}",
+            p_prefix,
+            out_style.apply_to(module.id),
+            path_style.apply_to(module.description.to_string())
+        );
+    } else {
+        println!("{}{}", p_prefix, out_style.apply_to(module.id));
+    }
+
+    if options.show_sync_modules() {
+        for sub in module.children().iter().filter(|m| options.all() || m.visible) {
+            print_module(
+                sub,
+                prefix,
+                rjust + 2,
+                verbose,
+                out_style,
+                path_style,
+                options
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Description

This patch improves the output for the `modules` command. Instead of
hiding all `sync` and `hidden` modules, it adds option flags to list
those as well. I had to introduce a hacky wrapper struct to create the
tree like output for the `sync` modules. I want to incorparate this in
the core crate when I have a better idea how to parse and layout this
modules.

### Usage

```
uvm-modules - List available modules for a specified unity version.

Usage:
  uvm-modules [options] [--category=CATEGORY...] <version>
  uvm-modules (-h | --help)

Options:
  -c=CATEGORY, --category=CATEGORY    filter by category
  -s, --show-sync-modules             list also sync modules
  -a, --all                           list also invisible modules
  -v, --verbose                       print more output
  -d, --debug                         print debug output
  --color WHEN                        Coloring: auto, always, never [default: auto]
  -h, --help                          show this help message and exit

Arguments:
  <version>                           The unity version to list modules for in the form of `2018.1.0f3`
```

### Examples

_plain list no details or sync modules_

`$uvm modules 2019.3.0b4`

prints:

```
visualstudio
documentation
android
appletv
ios
linux-mono
lumin
mac-il2cpp
webgl
windows-mono
language-ja
language-ko
language-zh-hans
language-zh-hant
```

_print sync modules_

`$uvm modules -s 2019.3.0b4`

prints:

```
visualstudio
documentation
android
  android-sdk-ndk-tools
  android-open-jdk
appletv
ios
linux-mono
lumin
mac-il2cpp
webgl
windows-mono
language-ja
language-ko
language-zh-hans
language-zh-hant
```

_print sync and hidden modules_

`$uvm modules -s -a 2019.3.0b4`

prints:

```
visualstudio
  mono
documentation
android
  android-sdk-ndk-tools
    android-sdk-platform-tools
    android-sdk-build-tools
    android-sdk-platforms
    android-ndk
  android-open-jdk
appletv
ios
linux-mono
lumin
mac-il2cpp
webgl
windows-mono
language-ja
language-ko
language-zh-hans
language-zh-hant
```

_print everything with full details_

`$uvm modules -v -s -a 2019.3.0b4`

prints:

```
Dev tools:
visualstudio - Script IDE with Unity integration and debugging support. Also installs Mono, required for Visual Studio for Mac to run
  mono - Required for Visual Studio for Mac

Documentation:
documentation - Offline Documentation

Platforms:
android - Allows building your Unity projects for the Android platform
  android-sdk-ndk-tools - Android SDK & NDK Tools 26.1.1
    android-sdk-platform-tools - Android SDK Platform Tools 28.0.1
    android-sdk-build-tools - Android SDK Build Tools 28.0.3
    android-sdk-platforms - Android SDK Platforms 28
    android-ndk - Android NDK r19
  android-open-jdk - Android OpenJDK 8u172-b11
appletv - Allows building your Unity projects for the AppleTV platform
ios - Allows building your Unity projects for the iOS platform
linux-mono - Allows building your Unity projects for the Linux-Mono platform
lumin - Allows building your Unity projects for the Lumin platform
mac-il2cpp - Allows building your Unity projects for the Mac-IL2CPP platform
webgl - Allows building your Unity projects for the WebGL platform
windows-mono - Allows building your Unity projects for the Windows-Mono platform

Language packs (Preview):
language-ja - 日本語
language-ko - 한국어
language-zh-hans - 简体中文
language-zh-hant - 繁體中文
```

## Changes

![IMPROVE] modules listing

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"