### PR TITLE
Improve macos module installer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -394,6 +403,15 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dmg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -775,6 +793,14 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1008,6 +1034,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plist"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "plist"
@@ -1377,6 +1414,11 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "safemem"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1975,6 +2017,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm-install-module"
+version = "2.3.0"
+dependencies = [
+ "console 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flexi_logger 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_cli 2.0.1",
+ "uvm_core 0.4.0",
+]
+
+[[package]]
 name = "uvm-launch"
 version = "2.3.0"
 dependencies = [
@@ -2067,6 +2123,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cluFlock 1.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs-2 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dmg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2219,6 +2276,7 @@ dependencies = [
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
@@ -2254,6 +2312,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs-2 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50b7e2b65c73137ec48935d50a5ae89b03150df566b7e14a1371df044e76765c"
+"checksum dmg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e565b39e64e4030c75320536cc18cd51f0636811c53d98a05f01ec5deb8dd8f"
 "checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
@@ -2299,6 +2358,7 @@ dependencies = [
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8"
@@ -2327,6 +2387,7 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
+"checksum plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c61ac2afed2856590ae79d6f358a24b85ece246d2aa134741a66d589519b7503"
 "checksum plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7316832d9ac5da02786bdc89a3faf0ca07070212b388766e969078fd593edc"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
@@ -2366,6 +2427,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"

--- a/install/uvm-install-module/Cargo.toml
+++ b/install/uvm-install-module/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "uvm-install-module"
+version = "2.3.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+edition = "2018"
+[dependencies]
+flexi_logger = "0.14.4"
+log = "0.4.5"
+console = "0.9.0"
+indicatif = "0.12.0"
+serde = "1.0"
+serde_derive = "1.0"
+uvm_cli = { path = "../../uvm_cli" }
+uvm_core = { path = "../../uvm_core" }

--- a/install/uvm-install-module/src/lib.rs
+++ b/install/uvm-install-module/src/lib.rs
@@ -1,0 +1,63 @@
+#[macro_use]
+extern crate serde_derive;
+
+use uvm_cli;
+
+use console::style;
+use console::Term;
+use std::io;
+use std::path::PathBuf;
+use uvm_cli::ColorOption;
+use uvm_core::install;
+
+#[derive(Debug, Deserialize)]
+pub struct Options {
+    arg_installer: PathBuf,
+    arg_destination: PathBuf,
+    flag_verbose: bool,
+    flag_color: ColorOption,
+}
+
+impl Options {
+    pub fn installer(&self) -> &PathBuf {
+        &self.arg_installer
+    }
+
+    pub fn destination(&self) -> &PathBuf {
+        &self.arg_destination
+    }
+}
+
+impl uvm_cli::Options for Options {
+    fn verbose(&self) -> bool {
+        self.flag_verbose
+    }
+
+    fn color(&self) -> &ColorOption {
+        &self.flag_color
+    }
+}
+
+pub struct UvmCommand {
+    stderr: Term,
+}
+
+impl Default for UvmCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UvmCommand {
+    pub fn new() -> UvmCommand {
+        UvmCommand {
+            stderr: Term::stderr(),
+        }
+    }
+
+    pub fn exec(&self, options: &Options) -> io::Result<()> {
+        install::install_module(options.installer(), options.destination())?;
+        self.stderr
+            .write_line(&format!("{}", style("success").green().bold()))
+    }
+}

--- a/install/uvm-install-module/src/main.rs
+++ b/install/uvm-install-module/src/main.rs
@@ -1,0 +1,23 @@
+use uvm_cli;
+use uvm_install_module;
+
+const USAGE: &str = "
+uvm-install-module - Install a unity module from given installer.
+
+Usage:
+  uvm-install-module [options] <installer> <destination>
+  uvm-install-module (-h | --help)
+
+Options:
+  -v, --verbose     print more output
+  --color WHEN      Coloring: auto, always, never [default: auto]
+  -h, --help        show this help message and exit
+";
+
+fn main() -> std::io::Result<()> {
+    let options: uvm_install_module::Options = uvm_cli::get_options(USAGE)?;
+    uvm_install_module::UvmCommand::new()
+        .exec(&options)
+        .unwrap_or_else(uvm_cli::print_error_and_exit);
+    Ok(())
+}

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -33,14 +33,15 @@ tempfile = "3"
 md-5 = { version = "0.8.0", features = ["std"] }
 hex-serde = "0.1.0"
 error-chain = "0.12.0"
+unzip = "0.1.0"
+[target.'cfg(target_os="macos")'.dependencies]
+dmg = "0.1.1"
 [target.'cfg(unix)'.dependencies]
 cluFlock = "1.2.5"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winver","memoryapi"] }
 libc = "0.2.43"
 tempfile = "3"
-[target.'cfg(target_os = "linux")'.dependencies]
-unzip = "0.1.0"
 
 [dev-dependencies]
 proptest = "0.9.4"

--- a/uvm_core/src/sys/mac/installer.rs
+++ b/uvm_core/src/sys/mac/installer.rs
@@ -1,16 +1,17 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::fs::DirBuilder;
 use std::io;
-
-use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 pub fn install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
-    _install_editor(installer, destination)
-    .map_err(|err| {
+    _install_editor(installer, destination).map_err(|err| {
         if destination.exists() {
-            debug!("Delete destination directory after failure {}", destination.display());
+            debug!(
+                "Delete destination directory after failure {}",
+                destination.display()
+            );
             fs::remove_dir_all(destination).unwrap_or_else(|err| {
                 error!("Failed to cleanup destination {}", destination.display());
                 error!("{}", err);
@@ -20,7 +21,13 @@ pub fn install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<
     })
 }
 
-fn _install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+fn _install_editor<P, D>(installer: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
     debug!(
         "install editor to destination: {} with installer: {}",
         destination.display(),
@@ -46,47 +53,196 @@ fn _install_editor(installer: &PathBuf, destination: &PathBuf) -> io::Result<()>
 
 pub fn install_module(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
     _install_module(installer, destination)
-    .map_err(|err| {
-        if destination.exists() {
-            debug!("Delete destination directory after failure {}", destination.display());
-            fs::remove_dir_all(destination).unwrap_or_else(|err| {
-                error!("Failed to cleanup destination {}", destination.display());
-                error!("{}", err);
-            })
-        }
-        err
-    })
 }
 
-fn _install_module(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+fn _install_module<P, D>(installer: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
+
     debug!(
         "install component {} to {}",
-        &installer.display(),
-        &destination.display()
+        installer.display(),
+        destination.display()
     );
-    let tmp_destination = destination.join("tmp");
 
-    if installer.extension() == Some(OsStr::new("pkg")) {
-        DirBuilder::new().recursive(true).create(&tmp_destination)?;
-        xar_pkg(installer, &tmp_destination)?;
-        untar_pkg(&tmp_destination, destination)?;
-        cleanup_ios_support_pkg(destination)?;
-        cleanup_pkg(&tmp_destination)?;
-        return Ok(());
+    match installer.extension() {
+        Some(ext) if ext == "pkg" => {
+            install_module_from_pkg(installer, destination).map_err(|err| {
+                cleanup_directory_failable(destination);
+                err
+            })
+        }
+
+        Some(ext) if ext == "zip" => {
+            install_module_from_zip(installer, destination).map_err(|err| {
+                cleanup_directory_failable(destination);
+                err
+            })
+        }
+
+        Some(ext) if ext == "po" => {
+            let destination_file = installer
+                .file_name()
+                .map(|name| destination.join(name))
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("Unable to read filename from path {}", installer.display()),
+                    )
+                })?;
+
+            let destination_already_existed = if destination.exists() {
+                false
+            } else {
+                DirBuilder::new().recursive(true).create(&destination)?;
+                true
+            };
+
+            install_language_po_file(installer, &destination_file).map_err(|err| {
+                cleanup_file_failable(&destination_file);
+                if destination_already_existed {
+                    cleanup_directory_failable(&destination)
+                }
+                err
+            })
+        }
+
+        Some(ext) if ext == "dmg" => install_module_from_dmg(installer, destination),
+
+        _ => Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "Wrong installer. Expect .pkg, .zip, .dmg or .po {}",
+                &installer.display()
+            ),
+        )),
     }
-
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        format!("Wrong installer. Expect .pkg {}", &installer.display()),
-    ))
 }
 
-fn cleanup_pkg(tmp_destination: &PathBuf) -> io::Result<()> {
+fn install_module_from_pkg<P, D>(installer: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
+
+    debug!(
+        "install module from pkg {} to {}",
+        installer.display(),
+        destination.display()
+    );
+    let tmp_destination = destination.join("tmp");
+    DirBuilder::new().recursive(true).create(&tmp_destination)?;
+    xar_pkg(installer, &tmp_destination)?;
+    untar_pkg(&tmp_destination, destination)?;
+    cleanup_ios_support_pkg(destination)?;
+    cleanup_pkg(&tmp_destination)?;
+    Ok(())
+}
+
+fn install_module_from_zip<P, D>(installer: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
+
+    debug!(
+        "install module from zip archive {} to {}",
+        installer.display(),
+        destination.display()
+    );
+
+    clean_directory(destination)?;
+    debug!("deploy zip archive to {}", destination.display());
+    deploy_zip(installer, destination)?;
+    Ok(())
+}
+
+fn install_language_po_file<P, D>(po: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    let po = po.as_ref();
+    let destination = destination.as_ref();
+    debug!("Copy po file {} to {}", po.display(), destination.display());
+    fs::copy(po, destination)?;
+    Ok(())
+}
+
+fn install_module_from_dmg<P, D>(installer: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    use dmg::Attach;
+
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
+
+    debug!(
+        "install from dmg {} to {}",
+        installer.display(),
+        destination.display()
+    );
+    let volume = Attach::new(installer).with()?;
+    debug!("installer mounted at {}", volume.mount_point.display());
+
+    let app_path = find_file_in_dir(&volume.mount_point, |entry| {
+        entry.file_name().to_str().unwrap().ends_with(".app")
+    })?;
+
+    copy_dir(app_path, destination)?;
+    Ok(())
+}
+
+fn copy_dir<P, D>(source: P, destination: D) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    let source = source.as_ref();
+    let destination = destination.as_ref();
+
+    debug!("Copy {} to {}", source.display(), destination.display());
+    let child = Command::new("cp")
+        .arg("-a")
+        .arg(source)
+        .arg(destination)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "failed to copy {} to {}\n{}",
+                source.display(),
+                destination.display(),
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_pkg<D: AsRef<Path>>(tmp_destination: D) -> io::Result<()> {
+    let tmp_destination = tmp_destination.as_ref();
     debug!("cleanup {}", &tmp_destination.display());
     fs::remove_dir_all(tmp_destination)
 }
 
-fn cleanup_ios_support_pkg(destination: &PathBuf) -> io::Result<()> {
+fn cleanup_ios_support_pkg<D: AsRef<Path>>(destination: D) -> io::Result<()> {
+    let destination = destination.as_ref();
     let tmp_ios_support_directory = destination.join("iOSSupport");
     if tmp_ios_support_directory.exists() {
         move_files(&tmp_ios_support_directory, &destination)?;
@@ -95,7 +251,8 @@ fn cleanup_ios_support_pkg(destination: &PathBuf) -> io::Result<()> {
     Ok(())
 }
 
-fn cleanup_editor_pkg(destination: &PathBuf) -> io::Result<()> {
+fn cleanup_editor_pkg<D: AsRef<Path>>(destination: D) -> io::Result<()> {
+    let destination = destination.as_ref();
     let tmp_unity_directory = destination.join("Unity");
     if !tmp_unity_directory.exists() {
         return Err(io::Error::new(
@@ -108,7 +265,10 @@ fn cleanup_editor_pkg(destination: &PathBuf) -> io::Result<()> {
     fs::remove_dir_all(&tmp_unity_directory)
 }
 
-fn xar_pkg(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+fn xar_pkg<P: AsRef<Path>, D: AsRef<Path>>(installer: P, destination: D) -> io::Result<()> {
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
+
     debug!(
         "unpack installer {} to temp destination {}",
         installer.display(),
@@ -137,7 +297,29 @@ fn xar_pkg(installer: &PathBuf, destination: &PathBuf) -> io::Result<()> {
     Ok(())
 }
 
-fn find_payload(dir: &PathBuf) -> io::Result<PathBuf> {
+fn find_file_in_dir<P, F>(dir: P, predicate: F) -> io::Result<PathBuf>
+where
+    P: AsRef<Path>,
+    F: FnMut(&std::fs::DirEntry) -> bool,
+{
+    let dir = dir.as_ref();
+    debug!("find file in directory {}", dir.display());
+    fs::read_dir(dir).and_then(|read_dir| {
+        read_dir
+            .filter_map(io::Result::ok)
+            .find(predicate)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("can't locate file in {}", &dir.display()),
+                )
+            })
+            .map(|entry| entry.path())
+    })
+}
+
+fn find_payload<P: AsRef<Path>>(dir: P) -> io::Result<PathBuf> {
+    let dir = dir.as_ref();
     debug!("find paylod in unpacked installer {}", dir.display());
     fs::read_dir(dir).and_then(|read_dir| {
         read_dir
@@ -151,7 +333,8 @@ fn find_payload(dir: &PathBuf) -> io::Result<PathBuf> {
                         &dir.display()
                     ),
                 )
-            }).map(|entry| entry.path())
+            })
+            .map(|entry| entry.path())
             .and_then(|path| Ok(path.join("Payload")))
             .and_then(|path| {
                 if path.exists() {
@@ -169,13 +352,20 @@ fn find_payload(dir: &PathBuf) -> io::Result<PathBuf> {
     })
 }
 
-fn untar_pkg(base_payload_path: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+fn untar_pkg<P: AsRef<Path>, D: AsRef<Path>>(
+    base_payload_path: P,
+    destination: D,
+) -> io::Result<()> {
+    let base_payload_path = base_payload_path.as_ref();
     let payload = find_payload(&base_payload_path)?;
     debug!("untar payload at {}", payload.display());
     tar(&payload, destination)
 }
 
-fn tar(source: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+fn tar<P: AsRef<Path>, D: AsRef<Path>>(source: P, destination: D) -> io::Result<()> {
+    let source = source.as_ref();
+    let destination = destination.as_ref();
+
     let tar_child = Command::new("tar")
         .arg("-C")
         .arg(destination)
@@ -199,7 +389,9 @@ fn tar(source: &PathBuf, destination: &PathBuf) -> io::Result<()> {
     Ok(())
 }
 
-fn move_files(source: &PathBuf, destination: &PathBuf) -> io::Result<()> {
+fn move_files<P: AsRef<Path>, D: AsRef<Path>>(source: P, destination: D) -> io::Result<()> {
+    let source = source.as_ref();
+    let destination = destination.as_ref();
     debug!(
         "move all files from {} into {}",
         source.display(),
@@ -224,4 +416,53 @@ fn move_files(source: &PathBuf, destination: &PathBuf) -> io::Result<()> {
         fs::rename(entry.path(), &new_location)?;
     }
     Ok(())
+}
+
+fn deploy_zip<P: AsRef<Path>, D: AsRef<Path>>(installer: P, destination: D) -> io::Result<()> {
+    use std::fs::File;
+    use unzip::Unzipper;
+
+    let installer = installer.as_ref();
+    let destination = destination.as_ref();
+
+    let file = File::open(installer)?;
+    let unzipper = Unzipper::new(file, destination);
+    unzipper.unzip()?;
+
+    Ok(())
+}
+
+fn cleanup_file_failable<P: AsRef<Path>>(file: P) {
+    let file = file.as_ref();
+    if file.exists() && file.is_file() {
+        debug!("cleanup file {}", &file.display());
+        fs::remove_file(file).unwrap_or_else(|err| {
+            error!("failed to cleanup file {}", &file.display());
+            error!("{}", err);
+        });
+    }
+}
+
+fn cleanup_directory_failable<P: AsRef<Path>>(dir: P) {
+    let dir = dir.as_ref();
+    if dir.exists() && dir.is_dir() {
+        debug!("cleanup directory {}", dir.display());
+        fs::remove_dir_all(dir).unwrap_or_else(|err| {
+            error!("failed to cleanup directory {}", dir.display());
+            error!("{}", err);
+        })
+    }
+}
+
+fn clean_directory<P: AsRef<Path>>(dir: P) -> io::Result<()> {
+    let dir = dir.as_ref();
+    debug!("clean output directory {}", dir.display());
+    if dir.exists() && dir.is_dir() {
+        debug!(
+            "directory exists, delete directory and create empty directory at {}",
+            dir.display()
+        );
+        fs::remove_dir_all(dir)?;
+    }
+    DirBuilder::new().recursive(true).create(dir)
 }


### PR DESCRIPTION
## Description

This is the first patch in a series to improve the module installation support on all system and reach Unity Hub parity. This patch concentrates on the macOS platform. It adds three new installer type supports

* zip
* po
* dmg

### Zip

On the macOS platform most modules are installed with `pkg` packages. The only exceptions are the new external android build tools packages. These are all configured as `zip` archives. The current implementation extracts the content of the requested archives to a chooses destination directory. The module description contains two new fields `renameFrom` and `renameTwo`. These final operations are not part of this patch because the install function has no context knowledge about the module to be installed.

### PO

`*.po` files are translation files which get installed directly into the `Unity.app` content directory. Unity Hub can't install them via the menu but the `modules.json` lists them.

### DMG

*Visual Studio* is the only module at the moment which is deployed and installed via a disk image. The implementation mounts the image and tries to fetch a file with the postfix `.app` and copies it to the destination location. There is no error handling or check if the application already exists at the moment.

### Missing installer types

One known module can't be installed at the moment. The `mono` package for *Visual Studio* is also deployed as a `pkg` installer. This installer needs to run with the default `pkg` tool. There is no way of discovering the differences between Unity's own modules in `pkg` format and other external ones without giving the install function more context.

### Helper command

I added a small helper command to test these new installer types. It's a direct copy of `uvm-install-editor` called `uvm-install-module`. It has no realworld usage and will be removed in due time.

## Changes

![ADD] ![MACOS] `zip` module installer support
![ADD] ![MACOS] `dmg` module installer support
![ADD] ![MACOS] `po` language files installer support
![ADD] helper command `uvm-install-module`

[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[MACOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"