### PR TITLE
Improve module destination fields as std::path::PathBuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,15 +901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "msdos_time"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,16 +1842,6 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unzip"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "transformation-pipeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,8 +2142,8 @@ dependencies = [
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unzip 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2272,12 +2253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "zip"
-version = "0.2.8"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2388,7 +2369,6 @@ dependencies = [
 "checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -2496,7 +2476,6 @@ dependencies = [
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum unzip 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90e59a2baae95b4b60ecd5a1ba39e9654b09b09bf813989c70f52c957c213dfd"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
@@ -2517,4 +2496,4 @@ dependencies = [
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
-"checksum zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e7341988e4535c60882d5e5f0b7ad0a9a56b080ade8bdb5527cb512f7b2180e0"
+"checksum zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c21bb410afa2bd823a047f5bda3adb62f51074ac7e06263b2c97ecdd47e9fc6"

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -34,7 +34,7 @@ md-5 = { version = "0.8.0", features = ["std"] }
 hex-serde = "0.1.0"
 hex = "0.4.0"
 error-chain = "0.12.0"
-unzip = "0.1.0"
+zip = "0.5.3"
 derive_deref = "1.1.0"
 [target.'cfg(target_os="macos")'.dependencies]
 dmg = "0.1.1"

--- a/uvm_core/src/lib.rs
+++ b/uvm_core/src/lib.rs
@@ -1,16 +1,5 @@
 #![recursion_limit = "1024"]
 
-
-
-
-
-
-
-
-
-#[cfg(target_os = "linux")]
-extern crate unzip;
-
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/uvm_core/src/sys/linux/unity/version/module.rs
+++ b/uvm_core/src/sys/linux/unity/version/module.rs
@@ -1,5 +1,6 @@
 use crate::unity::{Version};
 use crate::unity::Component;
+use std::path::{Path, PathBuf};
 
 pub struct ModulePart {
     pub component:Component,
@@ -9,8 +10,8 @@ pub struct ModulePart {
     pub main:bool,
     pub installed_size:u64,
     pub download_size:u64,
-    pub rename_from:Option<String>,
-    pub rename_to:Option<String>,
+    pub rename_from:Option<PathBuf>,
+    pub rename_to:Option<PathBuf>,
 }
 
 pub fn get_android_open_jdk_download_info<V: AsRef<Version>>(_version:V) -> ModulePart {
@@ -66,8 +67,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 120_000_000,
             download_size: 52_600_000,
-            rename_from: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/android-9".to_string()),
-            rename_to: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3".to_string())
+            rename_from: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/android-9").to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3").to_path_buf())
         },
         ModulePart {
             component: Component::AndroidSdkPlatforms,
@@ -77,8 +78,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 121_000_000,
             download_size: 60_600_000,
-            rename_from: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-9".to_string()),
-            rename_to: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28".to_string())
+            rename_from: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-9").to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28").to_path_buf())
         },
         ModulePart {
             component: Component::AndroidNdk,

--- a/uvm_core/src/sys/mac/unity/version/module.rs
+++ b/uvm_core/src/sys/mac/unity/version/module.rs
@@ -1,5 +1,6 @@
 use crate::unity::{Version};
 use crate::unity::Component;
+use std::path::{Path, PathBuf};
 
 pub struct ModulePart {
     pub component:Component,
@@ -9,8 +10,8 @@ pub struct ModulePart {
     pub main:bool,
     pub installed_size:u64,
     pub download_size:u64,
-    pub rename_from:Option<String>,
-    pub rename_to:Option<String>,
+    pub rename_from:Option<PathBuf>,
+    pub rename_to:Option<PathBuf>,
 }
 
 pub fn get_android_open_jdk_download_info<V: AsRef<Version>>(_version:V) -> ModulePart {
@@ -66,8 +67,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 120_000_000,
             download_size: 52_600_000,
-            rename_from: Some("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools/android-9".to_string()),
-            rename_to: Some("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3".to_string())
+            rename_from: Some(Path::new("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools/android-9").to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3").to_path_buf())
         },
         ModulePart {
             component: Component::AndroidSdkPlatforms,
@@ -77,8 +78,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 121_000_000,
             download_size: 60_600_000,
-            rename_from: Some("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/platforms/android-9".to_string()),
-            rename_to: Some("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28".to_string())
+            rename_from: Some(Path::new("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/platforms/android-9").to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28").to_path_buf())
         },
         ModulePart {
             component: Component::AndroidNdk,
@@ -88,8 +89,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 2_700_000_000,
             download_size: 770_000_000,
-            rename_from: Some(format!("{{UNITY_PATH}}/PlaybackEngines/AndroidPlayer/NDK/android-ndk-{}", ndk_version)),
-            rename_to: Some("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/NDK".to_string())
+            rename_from: Some(Path::new(&format!("{{UNITY_PATH}}/PlaybackEngines/AndroidPlayer/NDK/android-ndk-{}", ndk_version)).to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/PlaybackEngines/AndroidPlayer/NDK").to_path_buf())
         },
     ]
 }

--- a/uvm_core/src/sys/win/unity/version/module.rs
+++ b/uvm_core/src/sys/win/unity/version/module.rs
@@ -1,5 +1,6 @@
 use crate::unity::{Version};
 use crate::unity::Component;
+use std::path::{Path, PathBuf};
 
 pub struct ModulePart {
     pub component:Component,
@@ -9,8 +10,8 @@ pub struct ModulePart {
     pub main:bool,
     pub installed_size:u64,
     pub download_size:u64,
-    pub rename_from:Option<String>,
-    pub rename_to:Option<String>,
+    pub rename_from:Option<PathBuf>,
+    pub rename_to:Option<PathBuf>,
 }
 
 pub fn get_android_open_jdk_download_info<V: AsRef<Version>>(_version:V) -> ModulePart {
@@ -66,8 +67,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 120_000_000,
             download_size: 52_600_000,
-            rename_from: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9".to_string()),
-            rename_to: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3".to_string())
+            rename_from: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9").to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3").to_path_buf())
         },
         ModulePart {
             component: Component::AndroidSdkPlatforms,
@@ -77,8 +78,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: 121_000_000,
             download_size: 60_600_000,
-            rename_from: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9".to_string()),
-            rename_to: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28".to_string())
+            rename_from: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9").to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28").to_path_buf()),
         },
         ModulePart {
             component: Component::AndroidNdk,
@@ -88,8 +89,8 @@ pub fn get_android_sdk_ndk_download_info<V: AsRef<Version>>(version:V) -> Vec<Mo
             main: false,
             installed_size: ndk_install_size,
             download_size: ndk_download_size,
-            rename_from: Some(format!("{{UNITY_PATH}}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK/android-ndk-{}", ndk_version)),
-            rename_to: Some("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK".to_string())
+            rename_from: Some(Path::new(&format!("{{UNITY_PATH}}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK/android-ndk-{}", ndk_version)).to_path_buf()),
+            rename_to: Some(Path::new("{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/NDK").to_path_buf())
         },
     ]
 }


### PR DESCRIPTION
## Description

This patch makes handling of file paths from modules easier. Instead of serializing these values to `String` objects we use `std::path::PathBuf` instead.

## Changes

* ![IMPROVE] module destination fields as `std::path::PathBuf`

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"