### PR TITLE
Refactor Loader

### DIFF
--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -25,6 +25,7 @@ use uvm_core::install::InstallVariant;
 use uvm_core::unity::hub;
 use uvm_core::unity::hub::editors::{EditorInstallation, Editors};
 use uvm_core::unity::hub::paths;
+use uvm_core::unity::v2::Manifest;
 use uvm_core::unity::{Component, Installation, Version};
 #[cfg(unix)]
 use uvm_core::utils;
@@ -179,11 +180,15 @@ impl UvmCommand {
         editor_installed_lock: Arc<(EditorInstallLock, Condvar)>,
     ) -> io::Result<()> {
         pb.set_message(&format!("{}", style("download installer").yellow()));
+        let manifest = Manifest::load(&install_object.version).map_err(|_|
+            io::Error::new(io::ErrorKind::Other, "unable to load manifest")
+        )?;
 
         let mut installer_loader = install::Loader::new(
             install_object.variant.clone(),
-            install_object.version.clone(),
+            &manifest,
         );
+
         let sty = ProgressStyle::default_bar()
             .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ ")
             .progress_chars("=>-")

--- a/uvm_core/src/install/mod.rs
+++ b/uvm_core/src/install/mod.rs
@@ -1,18 +1,22 @@
-use std::path::PathBuf;
+use crate::unity::v2::Manifest;
 use crate::unity::Version;
+use std::path::PathBuf;
 pub mod error;
 mod installer;
 mod variant;
 
 pub use self::installer::Loader;
 
-pub use self::error::{UvmInstallError, UvmInstallErrorKind, ResultExt, Result};
+pub use self::error::{Result, ResultExt, UvmInstallError, UvmInstallErrorKind};
 
 pub use self::installer::install_editor;
 pub use self::installer::install_module;
 pub use self::variant::InstallVariant;
 
 pub fn download_installer(variant: InstallVariant, version: &Version) -> Result<PathBuf> {
-    let d = Loader::new(variant, version.to_owned());
+    let manifest: Result<Manifest> =
+        Manifest::load(version).map_err(|_| UvmInstallErrorKind::ManifestLoadFailed.into());
+    let manifest = manifest?;
+    let d = Loader::new(variant, &manifest);
     d.download()
 }

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -3,8 +3,12 @@ mod current_installation;
 pub mod hub;
 mod installation;
 pub mod urls;
-pub mod version;
+mod version;
 mod localization;
+
+pub mod v2 {
+    pub use super::version::manifest::v2::Manifest;
+}
 
 use core::iter::FromIterator;
 pub use self::component::Component;
@@ -15,7 +19,6 @@ pub use self::current_installation::CurrentInstallation;
 pub use self::installation::Installation;
 pub use self::version::all_versions;
 pub use self::version::manifest::Manifest;
-pub use self::version::manifest::v2::Manifest as ManifestV2;
 pub use self::version::manifest::ManifestIteratorItem;
 pub use self::version::manifest::MD5;
 pub use self::version::manifest::IniManifest;

--- a/uvm_core/src/unity/version/manifest/v2/mod.rs
+++ b/uvm_core/src/unity/version/manifest/v2/mod.rs
@@ -77,13 +77,12 @@ impl<'a> Manifest<'a> {
     }
 
     pub fn url(&self, component: Component) -> Option<Url> {
-        self.modules
-            .get(&component)
+        self.get(&component)
             .and_then(|m| Url::parse(&m.download_url).ok())
     }
 
     pub fn size(&self, component: Component) -> Option<u64> {
-        self.modules.get(&component).map(|m| m.download_size)
+        self.get(&component).map(|m| m.download_size)
     }
 
     pub fn version(&self) -> &Version {


### PR DESCRIPTION
Description
===========

For the new planned installer I need to slightly refactor the `uvm_core::installer::Loader` struct and adjust it's API. The plan to remove `install::Variant` in the long run and replace it directly with `uvm_core::unity::Component`. The `new` method is changed to accept any type which implements `Into<Component>`. I also realized that each loader instance loads its own copy of the manifest. This is unnecessary. Instead the loader is now constructed with a manifest ref instead. I changed the `download_installer` helper method to limit the API breakage.

Changes
=======

* ![CHANGE] `uvm_core::installer::Loader` API
* ![IMPROVE] loader manifest loading

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
