### PR TITLE
Add uvm_install_graph crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "daggy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_deref"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +494,11 @@ dependencies = [
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
@@ -1035,6 +1048,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2142,6 +2163,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm_install_graph"
+version = "0.1.0"
+dependencies = [
+ "daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_core 0.4.0",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,6 +2334,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2099ef075418d7b252af69583c831cde749af9423c2a212dea8895e8ea78841"
 "checksum derive_deref 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11554fdb0aa42363a442e0c4278f51c9621e20c1ce3bac51d79e60646f3b8b8f"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs-2 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50b7e2b65c73137ec48935d50a5ae89b03150df566b7e14a1371df044e76765c"
@@ -2315,6 +2347,7 @@ dependencies = [
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 "checksum flexi_logger 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d20d127f22dd09495f5a5de83dc9f51cf90932735b642910062c577082dd3b36"
 "checksum flexi_logger 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7992096ba2290bd35b86b282e72edae518a25aa9a067ff417bc017ae63ac5e22"
@@ -2380,6 +2413,7 @@ dependencies = [
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c61ac2afed2856590ae79d6f358a24b85ece246d2aa134741a66d589519b7503"
 "checksum plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7316832d9ac5da02786bdc89a3faf0ca07070212b388766e969078fd593edc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "uvm_core",
   "uvm_cli",
+  "uvm_install_graph",
   "commands/*",
   "install/*"
 ]

--- a/uvm_install_graph/Cargo.toml
+++ b/uvm_install_graph/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "uvm_install_graph"
+version = "0.1.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+description = "A graph view of a unity version manifest"
+repository = "https://github.com/Larusso/unity-version-manager"
+readme = "README.md"
+keywords = ["unity","version-manager"]
+categories = ["development-tools"]
+license = "Apache-2.0"
+edition = "2018"
+
+[badges]
+travis-ci = { repository = "Larusso/unity-version-manager", branch = "master" }
+appveyor = { repository = "Larusso/unity-version-manager", branch = "master", service = "github" }
+maintenance = { status = "experimental" }
+
+[dependencies]
+daggy = "0.6.0"
+fixedbitset = "0.1.8"
+itertools = "0.8.0"
+uvm_core = { path = "../uvm_core", version = "0.4.0" }
+[dev-dependencies]
+cfg-if = "0.1.9"
+stringreader = "0.1.1"

--- a/uvm_install_graph/README.md
+++ b/uvm_install_graph/README.md
@@ -1,0 +1,4 @@
+uvm_install_graph
+=================
+
+A simple [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) representation of a unity version and it's modules. This graph allows the traversal of to be installed modules in a topological order. It is also possible to query submodule and or dependencies for a given module.

--- a/uvm_install_graph/src/lib.rs
+++ b/uvm_install_graph/src/lib.rs
@@ -1,0 +1,218 @@
+//! **uvm_install_graph** is a helper library to visualize and traverse a unity installation manifest.
+use petgraph::visit::NodeIndexable;
+pub use daggy::petgraph;
+use daggy::petgraph::graph::DefaultIx;
+use daggy::petgraph::visit::Topo;
+use daggy::Dag;
+use daggy::NodeIndex;
+pub use daggy::Walker;
+use itertools::Itertools;
+use std::collections::HashSet;
+use std::fmt;
+use uvm_core::unity::{v2::Manifest, Component, Version};
+
+/// `InstallStatus` is a marker enum to mark nodes in the `InstallGraph` based on the known
+/// installation status. The default is **Unknown**.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstallStatus {
+    Unknown,
+    Missing,
+    Installed,
+}
+
+impl Default for InstallStatus {
+    fn default() -> InstallStatus {
+        InstallStatus::Unknown
+    }
+}
+
+impl fmt::Display for InstallStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InstallStatus::Missing => write!(f, "missing"),
+            InstallStatus::Installed => write!(f, "installed"),
+            _ => write!(f, "unknown"),
+        }
+    }
+}
+
+type DagNode = (Component, InstallStatus);
+type DagEdge = ();
+type ModulesDag = Dag<DagNode, DagEdge>;
+
+/// A simple [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
+/// representation of a unity version and it's modules. This graph allows the traversal of to
+/// be installed modules in a topological order.
+/// It is also possible to query submodule and or dependencies for a given module.
+#[derive(Debug)]
+pub struct InstallGraph<'a> {
+    manifest: &'a Manifest<'a>,
+    dag: ModulesDag,
+}
+
+impl<'a> From<&'a Manifest<'a>> for InstallGraph<'a> {
+    fn from(manifest: &'a Manifest<'a>) -> Self {
+        Self::from(manifest)
+    }
+}
+
+// use std::ops::Deref;
+//
+// impl<'a> Deref for InstallGraph<'a> {
+//     type Target = ModulesDag;
+//
+//     fn deref(&self) -> &Self::Target {
+//         &self.dag
+//     }
+// }
+
+impl<'a> InstallGraph<'a> {
+
+    /// The total number of nodes in the Dag.
+    pub fn node_count(&self) -> usize {
+        self.dag.node_count()
+    }
+
+    pub fn keep(&mut self, modules: &HashSet<Component>) {
+        self.dag = self.dag.filter_map(
+            |_n, (module, install_status)| {
+                if modules.contains(&module) {
+                    Some((*module, *install_status))
+                } else {
+                    None
+                }
+            },
+            |_, _| Some(()),
+        );
+    }
+
+    /// Builds a Dag representation of the given **Manifest**.
+    pub fn from(manifest: &'a Manifest<'a>) -> Self {
+        let dag = Self::build_dag(&manifest);
+        InstallGraph {
+            manifest,
+            dag
+        }
+    }
+
+    /// Creates a `Topo` traversal struct from the current graph to walk the graph in topological order.
+    pub fn topo(&self) -> Topo<NodeIndex, fixedbitset::FixedBitSet> {
+        Topo::new(&self.dag)
+    }
+
+    pub fn version(&self) -> &Version {
+        self.manifest.version()
+    }
+
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    /// Mark all nodes with the given `InstallStatus`.
+    pub fn mark_all(&mut self, install_status: InstallStatus) {
+        self.dag = self
+            .dag
+            .map(|_, (module, _)| (*module, install_status), |_, e| (*e));
+    }
+
+    /// Mark all nodes as `InstallStatus::Missing`.
+    pub fn mark_all_missing(&mut self) {
+        self.mark_all(InstallStatus::Missing)
+    }
+
+    /// Mark all nodes contained in `modules` as `InstallStatus::Installed`.
+    /// If the node is not found in `modules` the node gets marked as `InstallStatus::Missing`.
+    pub fn mark_installed(&mut self, modules: &HashSet<Component>) {
+        self.dag = self.dag.filter_map(
+            |_n, (module, _)| {
+                if modules.contains(&module) {
+                    Some((*module, InstallStatus::Installed))
+                } else {
+                    Some((*module, InstallStatus::Missing))
+                }
+            },
+            |_, _| Some(()),
+        );
+    }
+
+    /// Returns the component for the given node index.
+    pub fn component(&self, node: NodeIndex) -> Option<&Component> {
+        self.dag.node_weight(node).map(|(component, _)| component)
+    }
+
+    pub fn install_status(&self, node: NodeIndex) -> Option<&InstallStatus> {
+        self.dag.node_weight(node).map(|(_, status)| status)
+    }
+
+    pub fn get_node_id(&self, component: Component) -> Option<NodeIndex> {
+        self.dag.raw_nodes().iter().enumerate().find(|(_,node)| {
+            let (c, _) = node.weight;
+            c == component
+        }).map(|(index,_)| self.dag.from_index(index))
+    }
+
+    pub fn depth(&self, node: NodeIndex) -> usize {
+        self.dag
+            .recursive_walk(node, |g, n| g.parents(n).walk_next(g))
+            .iter(&self.dag)
+            .count()
+    }
+
+    /// Returns a **Vec** with all depended modules for the given node.
+    pub fn get_dependend_modules(&self, node: NodeIndex) -> Vec<(DagNode, NodeIndex)> {
+        self.dag
+            .recursive_walk(node, |g, n| g.parents(n).walk_next(g))
+            .iter(&self.dag)
+            .map(|(_, n)| (*self.dag.node_weight(n).unwrap(), n))
+            .collect()
+    }
+
+    /// Returns a **Vec** with all submodules for the given node.
+    pub fn get_sub_modules(&self, node: NodeIndex) -> Vec<(DagNode, NodeIndex)> {
+        let mut modules = Vec::new();
+        for (_, n) in self.dag.children(node).iter(&self.dag) {
+            modules.push((*self.dag.node_weight(n).unwrap(), n));
+            modules.append(&mut self.get_sub_modules(n));
+        }
+        modules
+    }
+
+    pub fn context(&self) -> &ModulesDag {
+        &self.dag
+    }
+
+    fn build_dag(manifest: &Manifest) -> ModulesDag {
+        let mut dag = Dag::new();
+
+        let editor = dag.add_node((Component::Editor, InstallStatus::default()));
+
+        for (c, m1) in manifest
+            .iter()
+            .sorted_by(|(a, _), (b, _)| b.to_string().cmp(&a.to_string()))
+        {
+            if *c != Component::Editor && m1.sync.is_none() {
+                let (_, n) = dag.add_child(editor, (), (*c, InstallStatus::default()));
+                Self::find_sync(&mut dag, &manifest, *c, n, 1);
+            }
+        }
+        dag
+    }
+
+    fn find_sync(
+        dag: &mut ModulesDag,
+        manifest: &Manifest,
+        parent: Component,
+        n: NodeIndex<DefaultIx>,
+        depth: u64,
+    ) {
+        for (c, m) in manifest.iter() {
+            match m.sync {
+                Some(id) if id == parent => {
+                    let (_, n) = dag.add_child(n, (), (*c, InstallStatus::default()));
+                    Self::find_sync(dag, manifest, *c, n, depth + 1);
+                }
+                _ => (),
+            };
+        }
+    }
+}

--- a/uvm_install_graph/tests/fixures/linux/2019.3.0a8_manifest.ini
+++ b/uvm_install_graph/tests/fixures/linux/2019.3.0a8_manifest.ini
@@ -1,0 +1,60 @@
+[Unity]
+title=Unity 2019.3.0a8
+description=Unity Editor
+url=LinuxEditorInstaller/Unity.tar.xz
+md5=631512a4d5924618ef792792e810ec9f
+install=true
+mandatory=false
+size=1070406436
+installedsize=3647805440
+version=2019.3.0a8
+[Android]
+title=Android Build Support
+description=Allows building your Unity projects for the Android platform
+url=MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-2019.3.0a8.pkg
+md5=2415a52f6642e541cd299485ba6d21bd
+install=false
+mandatory=false
+size=561621031
+installedsize=1536086000
+requires_unity=true
+[iOS]
+title=iOS Build Support
+description=Allows building your Unity projects for the iOS platform
+url=LinuxEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-2019.3.0a8.tar.xz
+md5=c4ba27fa111c711905618634198eb566
+install=false
+mandatory=false
+size=663866492
+installedsize=2860369920
+requires_unity=true
+[Mac-Mono]
+title=Mac Build Support (Mono)
+description=Allows building your Unity projects for the Mac-Mono platform
+url=MacEditorTargetInstaller/UnitySetup-Mac-Mono-Support-for-Editor-2019.3.0a8.pkg
+md5=7c6f1b2e8833df36e096144c05976255
+install=false
+mandatory=false
+size=135948312
+installedsize=484846000
+requires_unity=true
+[WebGL]
+title=WebGL Build Support
+description=Allows building your Unity projects for the WebGL platform
+url=LinuxEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-2019.3.0a8.tar.xz
+md5=12eef69c848c5d7726b64bb1fe1bf46d
+install=false
+mandatory=false
+size=294490464
+installedsize=1107773440
+requires_unity=true
+[Windows-Mono]
+title=Windows Build Support (Mono)
+description=Allows building your Unity projects for the Windows-Mono platform
+url=MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-2019.3.0a8.pkg
+md5=093a2b1a5762b62a03168fb9fde63a73
+install=false
+mandatory=false
+size=108050459
+installedsize=356135000
+requires_unity=true

--- a/uvm_install_graph/tests/fixures/linux/mod.rs
+++ b/uvm_install_graph/tests/fixures/linux/mod.rs
@@ -1,0 +1,1 @@
+pub const UNITY_2019_INI:&str = include_str!("2019.3.0a8_manifest.ini");

--- a/uvm_install_graph/tests/fixures/mac/2019.3.0a8_manifest.ini
+++ b/uvm_install_graph/tests/fixures/mac/2019.3.0a8_manifest.ini
@@ -1,0 +1,116 @@
+[Unity]
+title=Unity 2019.3.0a8
+description=Unity Editor
+url=MacEditorInstaller/Unity.pkg
+install=true
+mandatory=false
+size=1405057027
+installedsize=3430390000
+version=2019.3.0a8
+md5=09298976a9ced485a09a94987bb4177a
+[Mono]
+title=Mono for Visual Studio for Mac
+description=Required for Visual Studio for Mac
+url=https://go.microsoft.com/fwlink/?linkid=2087047
+install=false
+mandatory=false
+size=500000000
+installedsize=1524000000
+sync=VisualStudio
+hidden=true
+extension=pkg
+[VisualStudio]
+title=Visual Studio for Mac
+description=Script IDE with Unity integration and debugging support. Also installs Mono, required for Visual Studio for Mac to run
+url=https://go.microsoft.com/fwlink/?linkid=2086937
+install=true
+mandatory=false
+size=820000000
+installedsize=2304000000
+eulamessage=Please review and accept the license terms before downloading and installing Visual Studio for Mac and Mono.
+eulalabel1=Visual Studio for Mac License Terms
+eulaurl1=https://go.microsoft.com/fwlink/?linkid=2092535
+eulalabel2=Mono License Terms
+eulaurl2=http://www.mono-project.com/docs/faq/licensing/
+appidentifier=com.microsoft.visual-studio
+extension=dmg
+[Android]
+title=Android Build Support
+description=Allows building your Unity projects for the Android platform
+url=MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=561621031
+installedsize=1536086000
+requires_unity=true
+md5=2415a52f6642e541cd299485ba6d21bd
+[iOS]
+title=iOS Build Support
+description=Allows building your Unity projects for the iOS platform
+url=MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=1014757415
+installedsize=2791125000
+requires_unity=true
+md5=f6387e8e11b5db26a1461a4accf4ecf8
+[AppleTV]
+title=tvOS Build Support
+description=Allows building your Unity projects for the AppleTV platform
+url=MacEditorTargetInstaller/UnitySetup-AppleTV-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=518674471
+installedsize=1479011000
+requires_unity=true
+md5=f0e72c06fe791f388add64be687be3bc
+[Linux-Mono]
+title=Linux Build Support (Mono)
+description=Allows building your Unity projects for the Linux-Mono platform
+url=MacEditorTargetInstaller/UnitySetup-Linux-Mono-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=85452817
+installedsize=247315000
+requires_unity=true
+md5=53c051ef052e7351d5fab6b55e2ad82c
+[Mac-IL2CPP]
+title=Mac Build Support (IL2CPP)
+description=Allows building your Unity projects for the Mac-IL2CPP platform
+url=MacEditorTargetInstaller/UnitySetup-Mac-IL2CPP-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=139601948
+installedsize=495287000
+requires_unity=true
+md5=0a521297aa2fd757fe9bfeccf3a02f65
+[WebGL]
+title=WebGL Build Support
+description=Allows building your Unity projects for the WebGL platform
+url=MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=440641562
+installedsize=990495000
+requires_unity=true
+md5=a5d3fc69efbfedf5a641270427d4fe75
+[Windows-Mono]
+title=Windows Build Support (Mono)
+description=Allows building your Unity projects for the Windows-Mono platform
+url=MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=108050459
+installedsize=356135000
+requires_unity=true
+md5=093a2b1a5762b62a03168fb9fde63a73
+[Lumin]
+title=Lumin OS (Magic Leap) Build Support
+description=Allows building your Unity projects for the Lumin platform
+url=MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-2019.3.0a8.pkg
+install=false
+mandatory=false
+size=237570068
+installedsize=809764000
+requires_unity=true
+md5=9b4ea653b88048b642f87d8bc25a63a9

--- a/uvm_install_graph/tests/fixures/mac/mod.rs
+++ b/uvm_install_graph/tests/fixures/mac/mod.rs
@@ -1,0 +1,1 @@
+pub const UNITY_2019_INI:&str = include_str!("2019.3.0a8_manifest.ini");

--- a/uvm_install_graph/tests/fixures/mod.rs
+++ b/uvm_install_graph/tests/fixures/mod.rs
@@ -1,0 +1,14 @@
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        mod mac;
+        pub use self::mac::*;
+    } else if #[cfg(target_os = "windows")] {
+        mod win;
+        pub use self::win::*;
+    } else if #[cfg(target_os = "linux")] {
+        mod linux;
+        pub use self::linux::*;
+    } else {
+        compile_error!("uvm doens't compile for this platform");
+    }
+}

--- a/uvm_install_graph/tests/fixures/win/2019.3.0a8_manifest.ini
+++ b/uvm_install_graph/tests/fixures/win/2019.3.0a8_manifest.ini
@@ -1,0 +1,155 @@
+[Unity]
+title=Unity 2019.3.0a8
+description=Unity Editor for building your games
+url=Windows64EditorInstaller/UnitySetup64.exe
+install=true
+mandatory=false
+size=1003186
+size_h=980M
+installedsize=3189668
+cmd="{FILENAME}" -UI=reduced /D={INSTDIR}
+md5=e52dc9678dd6aa0a31cf7968249adddf
+[VisualStudio]
+title=Microsoft Visual Studio Community 2019
+description=Downloads and installs Microsoft Visual Studio Community 2019. By installing this you accept the license terms for Visual Studio.
+url=https://go.microsoft.com/fwlink/?linkid=2086755
+install=true
+mandatory=false
+size=1331200
+size_h=1.26M
+installedsize=1300000
+cmd="{FILENAME}" --productId "Microsoft.VisualStudio.Product.Community" --add "Microsoft.VisualStudio.Workload.ManagedGame" --add "Microsoft.VisualStudio.Workload.NativeDesktop" --add "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" --add "Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop" --campaign "Unity3d_Unity" --passive --norestart --wait
+filename=vs_community.exe
+eulamessage=Please review and accept the license terms before downloading and installing Microsoft Visual Studio.
+eulaurl1=https://go.microsoft.com/fwlink/?linkid=2092534
+eulalabel1=Visual Studio 2019 Community License Terms
+use_vs_editor=true
+[VisualStudioProfessionalUnityWorkload]
+title=Unity Game Development for Microsoft Visual Studio Professional 2019
+description=Unity Game Development for Microsoft Visual Studio Professional 2019. By installing this you accept the license terms for Visual Studio Tools for Unity.
+url=https://aka.ms/vs/16/release/vs_Professional.exe
+install=false
+mandatory=false
+size=1000000
+size_h=1.0M
+installedsize=320000
+cmd="{FILENAME}" --add "Microsoft.VisualStudio.Workload.ManagedGame" --add "Microsoft.VisualStudio.Workload.NativeDesktop" --add "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" --add "Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop" --passive --norestart --wait
+filename=vs_Professional.exe
+eulamessage=Please review and accept the license terms before downloading and installing Unity Game Development for Microsoft Visual Studio Professional 2019.
+eulaurl1=https://go.microsoft.com/fwlink/?linkid=617019
+eulalabel1=Visual Studio Tools for Unity License Terms
+use_vs_editor=true
+[VisualStudioEnterpriseUnityWorkload]
+title=Unity Game Development for Microsoft Visual Studio Enterprise 2019
+description=Unity Game Development for Microsoft Visual Studio Enterprise 2019. By installing this you accept the license terms for Visual Studio Tools for Unity.
+url=https://aka.ms/vs/16/release/vs_Enterprise.exe
+install=false
+mandatory=false
+size=1000000
+size_h=1.0M
+installedsize=320000
+cmd="{FILENAME}" --add "Microsoft.VisualStudio.Workload.ManagedGame" --add "Microsoft.VisualStudio.Workload.NativeDesktop" --add "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" --add "Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop" --passive --norestart --wait
+filename=vs_Enterprise.exe
+eulamessage=Please review and accept the license terms before downloading and installing Unity Game Development for Microsoft Visual Studio Enterprise 2019.
+eulaurl1=https://go.microsoft.com/fwlink/?LinkId=617019
+eulalabel1=Visual Studio Tools for Unity License Terms
+use_vs_editor=true
+[Android]
+title=Android Build Support
+description=Android Playback Engine
+url=TargetSupportInstaller/UnitySetup-Android-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=415910
+size_h=407M
+installedsize=1536339
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=c3996e322461c64ddb409dcf8ecfd898
+[iOS]
+title=iOS Build Support
+description=iOS Playback Engine
+url=TargetSupportInstaller/UnitySetup-iOS-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=655311
+size_h=640M
+installedsize=2798572
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=d0876cf0c745e3d52c215ee78c113df2
+[AppleTV]
+title=tvOS Build Support
+description=tvOS Playback Engine
+url=TargetSupportInstaller/UnitySetup-AppleTV-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=335396
+size_h=328M
+installedsize=1486494
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=05562c752ba1453f7efa5b5cc53fc989
+[Linux-Mono]
+title=Linux Build Support (Mono)
+description=Linux Playback Engine (Mono Scripting Backend)
+url=TargetSupportInstaller/UnitySetup-Linux-Mono-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=53140
+size_h=52M
+installedsize=247728
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=4b5cc31d7d4c8b8b051b8adf343dbc5d
+[Mac-Mono]
+title=Mac Build Support (Mono)
+description=Mac Playback Engine (Mono Scripting Backend)
+url=TargetSupportInstaller/UnitySetup-Mac-Mono-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=85150
+size_h=84M
+installedsize=485307
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=1c53a81ef15b5336ff1998142b9285bc
+[Universal-Windows-Platform]
+title=Universal Windows Platform Build Support
+description=UWP Playback Engine
+url=TargetSupportInstaller/UnitySetup-Universal-Windows-Platform-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=271975
+size_h=266M
+installedsize=2028356
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=aa1da05741e88624e1bd24f7871cc673
+[WebGL]
+title=WebGL Build Support
+description=WebGL Playback Engine
+url=TargetSupportInstaller/UnitySetup-WebGL-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=240289
+size_h=235M
+installedsize=888142
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=9afac39199238f21508d8a101f1e846f
+[Windows-IL2CPP]
+title=Windows Build Support (IL2CPP)
+description=Windows Playback Engine (IL2CPP Scripting Backend)
+url=TargetSupportInstaller/UnitySetup-Windows-IL2CPP-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=64353
+size_h=63M
+installedsize=342337
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=81bd737b62045bd663100bd8d3e3420d
+[Lumin]
+title=Lumin OS (Magic Leap) Build Support
+description=Lumin OS Playback Engine
+url=TargetSupportInstaller/UnitySetup-Lumin-Support-for-Editor-2019.3.0a8.exe
+install=false
+mandatory=false
+size=145072
+size_h=142M
+installedsize=810272
+cmd="{FILENAME}" /S /D={MODULEDIR}
+md5=c106065833029ae6d42cb3f7b014f591

--- a/uvm_install_graph/tests/fixures/win/mod.rs
+++ b/uvm_install_graph/tests/fixures/win/mod.rs
@@ -1,0 +1,1 @@
+pub const UNITY_2019_INI:&str = include_str!("2019.3.0a8_manifest.ini");

--- a/uvm_install_graph/tests/graph_tests.rs
+++ b/uvm_install_graph/tests/graph_tests.rs
@@ -1,0 +1,286 @@
+use std::collections::HashSet;
+use stringreader::StringReader;
+use uvm_core::unity::v2::Manifest;
+use uvm_core::unity::{Component, Version};
+use uvm_install_graph::{InstallGraph, InstallStatus, Walker};
+mod fixures;
+use itertools::Itertools;
+
+#[test]
+fn create_graph_from_manifest() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+
+    let _graph = InstallGraph::from(&manifest);
+}
+
+#[test]
+fn retrieve_nodes() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+
+    let graph = InstallGraph::from(&manifest);
+    let node_idx = graph.get_node_id(Component::Android).unwrap();
+
+    assert_eq!(*graph.component(node_idx).unwrap(), Component::Android);
+}
+
+#[test]
+fn install_status() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+    let mut graph = InstallGraph::from(&manifest);
+
+    let node_android = graph.get_node_id(Component::Android).unwrap();
+    let node_ios = graph.get_node_id(Component::Ios).unwrap();
+    let node_webgl = graph.get_node_id(Component::WebGl).unwrap();
+    let node_editor = graph.get_node_id(Component::Editor).unwrap();
+
+    assert_eq!(
+        graph.install_status(node_android),
+        Some(&InstallStatus::Unknown)
+    );
+    assert_eq!(
+        graph.install_status(node_ios),
+        Some(&InstallStatus::Unknown)
+    );
+    assert_eq!(
+        graph.install_status(node_webgl),
+        Some(&InstallStatus::Unknown)
+    );
+    assert_eq!(
+        graph.install_status(node_editor),
+        Some(&InstallStatus::Unknown)
+    );
+
+    let mut installed_set: HashSet<Component> = HashSet::new();
+    installed_set.insert(Component::Editor);
+    installed_set.insert(Component::Android);
+    graph.mark_installed(&installed_set);
+
+    assert_eq!(
+        graph.install_status(node_android),
+        Some(&InstallStatus::Installed)
+    );
+    assert_eq!(
+        graph.install_status(node_ios),
+        Some(&InstallStatus::Missing)
+    );
+    assert_eq!(
+        graph.install_status(node_webgl),
+        Some(&InstallStatus::Missing)
+    );
+    assert_eq!(
+        graph.install_status(node_editor),
+        Some(&InstallStatus::Installed)
+    );
+
+    graph.mark_all_missing();
+
+    assert_eq!(
+        graph.install_status(node_android),
+        Some(&InstallStatus::Missing)
+    );
+    assert_eq!(
+        graph.install_status(node_ios),
+        Some(&InstallStatus::Missing)
+    );
+    assert_eq!(
+        graph.install_status(node_webgl),
+        Some(&InstallStatus::Missing)
+    );
+    assert_eq!(
+        graph.install_status(node_editor),
+        Some(&InstallStatus::Missing)
+    );
+
+    graph.mark_all(InstallStatus::Installed);
+
+    assert_eq!(
+        graph.install_status(node_android),
+        Some(&InstallStatus::Installed)
+    );
+    assert_eq!(
+        graph.install_status(node_ios),
+        Some(&InstallStatus::Installed)
+    );
+    assert_eq!(
+        graph.install_status(node_webgl),
+        Some(&InstallStatus::Installed)
+    );
+    assert_eq!(
+        graph.install_status(node_editor),
+        Some(&InstallStatus::Installed)
+    );
+}
+
+#[test]
+fn modules_dependencies() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+    let graph = InstallGraph::from(&manifest);
+
+    let node_android = graph.get_node_id(Component::Android).unwrap();
+    let node_android_sdk_ndk_tools = graph.get_node_id(Component::AndroidSdkNdkTools).unwrap();
+    let node_android_ndk = graph.get_node_id(Component::AndroidNdk).unwrap();
+    let node_editor = graph.get_node_id(Component::Editor).unwrap();
+
+    let depended = graph.get_dependend_modules(node_android_ndk);
+    let mut iter = depended.iter();
+
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidSdkNdkTools, InstallStatus::Unknown),
+            node_android_sdk_ndk_tools
+        ))
+    );
+
+    assert_eq!(
+        iter.next(),
+        Some(&((Component::Android, InstallStatus::Unknown), node_android))
+    );
+
+    assert_eq!(
+        iter.next(),
+        Some(&((Component::Editor, InstallStatus::Unknown), node_editor))
+    );
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn sub_modules() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+    let graph = InstallGraph::from(&manifest);
+
+    let node_android = graph.get_node_id(Component::Android).unwrap();
+    let node_open_jdk = graph.get_node_id(Component::AndroidOpenJdk).unwrap();
+    let node_android_sdk_ndk_tools = graph.get_node_id(Component::AndroidSdkNdkTools).unwrap();
+    let node_android_sdk_platforms = graph.get_node_id(Component::AndroidSdkPlatforms).unwrap();
+    let node_android_sdk_platform_tools = graph
+        .get_node_id(Component::AndroidSdkPlatformTools)
+        .unwrap();
+    let node_android_sdk_build_tools = graph.get_node_id(Component::AndroidSdkBuildTools).unwrap();
+    let node_android_ndk = graph.get_node_id(Component::AndroidNdk).unwrap();
+
+    let depended = graph.get_sub_modules(node_android);
+    let mut iter = depended
+        .iter()
+        .sorted_by(|((a, _), _), ((b, _), _)| b.to_string().cmp(&a.to_string()));
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidSdkPlatforms, InstallStatus::Unknown),
+            node_android_sdk_platforms
+        ))
+    );
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidSdkPlatformTools, InstallStatus::Unknown),
+            node_android_sdk_platform_tools
+        ))
+    );
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidSdkNdkTools, InstallStatus::Unknown),
+            node_android_sdk_ndk_tools
+        ))
+    );
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidSdkBuildTools, InstallStatus::Unknown),
+            node_android_sdk_build_tools
+        ))
+    );
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidOpenJdk, InstallStatus::Unknown),
+            node_open_jdk
+        ))
+    );
+    assert_eq!(
+        iter.next(),
+        Some(&(
+            (Component::AndroidNdk, InstallStatus::Unknown),
+            node_android_ndk
+        ))
+    );
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn topo() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+    let mut graph = InstallGraph::from(&manifest);
+
+    let node_android_ndk = graph.get_node_id(Component::AndroidNdk).unwrap();
+    let ndk_dependencies = graph.get_dependend_modules(node_android_ndk);
+    let mut keep: HashSet<Component> = ndk_dependencies
+        .into_iter()
+        .map(|((component, _), _)| component)
+        .collect();
+    keep.insert(Component::AndroidNdk);
+    graph.keep(&keep);
+    let mut topo = graph.topo();
+
+    assert_eq!(
+        topo.walk_next(graph.context()),
+        graph.get_node_id(Component::Editor)
+    );
+    assert_eq!(
+        topo.walk_next(graph.context()),
+        graph.get_node_id(Component::Android)
+    );
+    assert_eq!(
+        topo.walk_next(graph.context()),
+        graph.get_node_id(Component::AndroidSdkNdkTools)
+    );
+    assert_eq!(
+        topo.walk_next(graph.context()),
+        graph.get_node_id(Component::AndroidNdk)
+    );
+    assert_eq!(topo.walk_next(graph.context()), None);
+}
+
+#[test]
+fn keep() {
+    let ini = fixures::UNITY_2019_INI;
+    let reader = StringReader::new(ini);
+    let version = Manifest::read_manifest_version(reader).unwrap();
+    let reader = StringReader::new(ini);
+    let manifest = Manifest::from_reader(&version, reader).expect("a manifest");
+    let mut graph = InstallGraph::from(&manifest);
+
+    assert!(graph.node_count() >= 2);
+
+    let mut keep_set: HashSet<Component> = HashSet::new();
+    keep_set.insert(Component::Editor);
+    keep_set.insert(Component::Android);
+    graph.keep(&keep_set);
+
+    assert!(graph.node_count() == 2);
+}


### PR DESCRIPTION
## Description

This patch adds a new helper crate `uvm_install_graph`. A simple [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) representation of a unity version and it's modules. This graph allows the traversal of to be installed modules in a topological order.
It is also possible to query submodule and or dependencies for a given module. This graph will be used by the new installer to walk the version manifest in topological order and install missing/requested modules.

## Changes

* ![ADD] ![NEW] `uvm_install_graph` crate

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"