### PR TITLE
Refactor installer API

### DIFF
--- a/install/uvm-install-editor/src/lib.rs
+++ b/install/uvm-install-editor/src/lib.rs
@@ -57,7 +57,7 @@ impl UvmCommand {
     }
 
     pub fn exec(&self, options: &Options) -> io::Result<()> {
-        install::install_editor(options.installer(), options.destination())?;
+        install::install_editor(options.installer(), Some(options.destination()))?;
         self.stderr
             .write_line(&format!("{}", style("success").green().bold()))
     }

--- a/install/uvm-install-module/src/lib.rs
+++ b/install/uvm-install-module/src/lib.rs
@@ -56,7 +56,7 @@ impl UvmCommand {
     }
 
     pub fn exec(&self, options: &Options) -> io::Result<()> {
-        install::install_module(options.installer(), options.destination())?;
+        install::install_module(options.installer(), Some(options.destination()))?;
         self.stderr
             .write_line(&format!("{}", style("success").green().bold()))
     }

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -251,22 +251,20 @@ impl UvmCommand {
             }
         }
 
-        let destination = install_object.clone().destination.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "Missing installation destination")
-        })?;
+        let destination = install_object.clone().destination;
 
         pb.set_message(&format!("{}", style("installing").yellow()));
         debug!(
-            "install {} to {}",
-            &install_object.variant,
-            &destination.display()
+            "install {}",
+            &install_object.variant
         );
+
         let install_f = match &install_object.variant {
             InstallVariant::Editor => install::install_editor,
             _ => install::install_module,
         };
 
-        install_f(&installer, &destination)
+        install_f(&installer, destination.as_ref())
             .map(|result| {
                 debug!("installation finished {}.", &install_object.variant);
                 pb.finish_with_message(&format!("{}", style("done").green().bold()));


### PR DESCRIPTION
## Description

To support all new and old support modules I need to adjust the installer API. At the moment each module installation required a destination path for the installation. Sadly some modules only have no destination configured and either use a default value or none at all. That is a problem because validating which default value to use is platform and installer type specific. Which means that this can only be handled in the installer directly. I made the decision to change the API for `install_editor` and `install_module` to support an `Option<AsRef<Path>>` value. The installer will valid the destination and fail if a destination is required but not passed down.

## Changes

* ![CHANGE] installer API

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"