### PR TITLE
Add uvm_move_dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "uvm_core",
   "uvm_cli",
   "uvm_install_graph",
+  "uvm_move_dir",
   "commands/*",
   "install/*"
 ]

--- a/uvm_move_dir/Cargo.toml
+++ b/uvm_move_dir/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uvm_move_dir"
+version = "0.1.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+description = "Opinionated directory move operation"
+repository = "https://github.com/Larusso/unity-version-manager"
+readme = "README.md"
+keywords = ["unity","version-manager"]
+categories = ["development-tools"]
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+tempfile = "3"
+log = "0.4.8"
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["errhandlingapi"] }
+widestring = "0.4.0"

--- a/uvm_move_dir/README.md
+++ b/uvm_move_dir/README.md
@@ -1,0 +1,15 @@
+uvm_move_dir
+============
+
+Opinionated directory move operations.
+The default `rename` operation from [`std::fs::rename`] doesn't work for some usecases `uvm` has during
+installation of certain modules. The special `move_dir` function in this crate allows:
+
+* to move files into the same path.
+* rename directories
+
+A special windows invocation of [`MoveFileExW`] without the `MOVEFILE_REPLACE_EXISTING` flag, which [`std::fs::rename`] sets,
+allows moving of directories also under windows.
+
+[`MoveFileExW`]: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
+[`std::fs::rename`]: https://doc.rust-lang.org/std/fs/fn.rename.html

--- a/uvm_move_dir/src/lib.rs
+++ b/uvm_move_dir/src/lib.rs
@@ -1,0 +1,77 @@
+use log::*;
+use std::fs;
+use std::io;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[cfg(windows)]
+mod win_move_file;
+
+fn visit_dirs<P: AsRef<Path>>(
+    dir: P,
+    cb: &mut dyn for<'r> std::ops::FnMut(&'r fs::DirEntry),
+) -> io::Result<()> {
+    let dir = dir.as_ref();
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                visit_dirs(&path, cb)?;
+            } else {
+                cb(&entry);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn recursive_file_count<P: AsRef<Path>>(dir: P) -> io::Result<u64> {
+    let mut count = 0;
+    visit_dirs(dir, &mut |_| count += 1)?;
+    Ok(count)
+}
+
+pub fn move_dir<S: AsRef<Path>, D: AsRef<Path>>(source: S, destination: D) -> io::Result<()> {
+    let destination = destination.as_ref();
+    let source = source.as_ref();
+    if source.starts_with(destination) {
+        trace!("attempt to move files some levels up!");
+        let tempdir = tempdir()?;
+        let sub = tempdir.path().join("sub");
+        #[cfg(unix)]
+        fs::DirBuilder::new().create(&sub)?;
+        #[cfg(unix)]
+        fs::rename(source, &sub)?;
+        #[cfg(windows)]
+        win_move_file::rename(source, &sub)?;
+
+        move_dir(&sub, destination).map_err(|err|{
+            match fs::rename(&sub,source) {
+                Err(err) => err,
+                _ => err
+            }
+        })?;
+    } else {
+        trace!("rename dir");
+        if destination.exists() {
+            if recursive_file_count(destination)? > 0 {
+                return Err(io::Error::from(io::ErrorKind::AlreadyExists));
+            } else {
+                fs::remove_dir_all(destination)?;
+                move_dir(source, destination)?;
+            }
+        } else {
+            #[cfg(unix)]
+            fs::DirBuilder::new()
+                .recursive(true)
+                .create(destination)?;
+            #[cfg(unix)]
+            fs::rename(source, destination)?;
+            #[cfg(windows)]
+            win_move_file::rename(source, destination)?;
+        }
+    }
+
+    Ok(())
+}

--- a/uvm_move_dir/src/win_move_file.rs
+++ b/uvm_move_dir/src/win_move_file.rs
@@ -1,0 +1,24 @@
+use std::io;
+use std::path::Path;
+
+pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
+    use winapi::um::winbase;
+    use winapi::um::errhandlingapi;
+    use widestring::{U16CString};
+
+    let from = from.as_ref();
+    let to = to.as_ref();
+
+    let from = U16CString::from_os_str(from).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+    let to = U16CString::from_os_str(to).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    unsafe {
+        let success = winbase::MoveFileW(from.as_ptr(), to.as_ptr());
+        if success == 0 {
+            let error_code = errhandlingapi::GetLastError();
+            Err(io::Error::from_raw_os_error(error_code as i32))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/uvm_move_dir/tests/helper/mod.rs
+++ b/uvm_move_dir/tests/helper/mod.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+use std::io;
+use std::fs::DirBuilder;
+
+pub fn setup_directory_structure<P: AsRef<Path>>(target:P) -> io::Result<()> {
+    let target = target.as_ref();
+    let subfile0 = target.join("file0.txt");
+    let subdir1 = target.join("subdir1");
+    let subfile1 = subdir1.join("file1.txt");
+    let subdir2 = target.join("subdir2");
+    let subfile2 = subdir2.join("file2.txt");
+
+    DirBuilder::new().recursive(true).create(&subdir1).unwrap();
+    DirBuilder::new().recursive(true).create(&subdir2).unwrap();
+
+    std::fs::File::create(subfile0).unwrap();
+    std::fs::File::create(subfile1).unwrap();
+    std::fs::File::create(subfile2).unwrap();
+    Ok(())
+}
+
+pub fn assert_moved_structure_at<P: AsRef<Path>>(target:P) {
+    let target = target.as_ref();
+    let subfile0 = target.join("file0.txt");
+    let subdir1 = target.join("subdir1");
+    let subfile1 = subdir1.join("file1.txt");
+    let subdir2 = target.join("subdir2");
+    let subfile2 = subdir2.join("file2.txt");
+
+    assert!(subfile0.exists(), format!("{} should exist", subfile0.display()));
+    assert!(subdir1.exists(), format!("{} should exist", subdir1.display()));
+    assert!(subfile1.exists(), format!("{} should exist", subfile1.display()));
+    assert!(subdir2.exists(), format!("{} should exist", subdir2.display()));
+    assert!(subfile2.exists(), format!("{} should exist", subfile2.display()));
+}

--- a/uvm_move_dir/tests/move_dir_inner_tests.rs
+++ b/uvm_move_dir/tests/move_dir_inner_tests.rs
@@ -1,0 +1,67 @@
+mod helper;
+use self::helper::*;
+use uvm_move_dir::*;
+use std::fs::DirBuilder;
+use tempfile::TempDir;
+
+#[test]
+fn move_dir_one_level_up() {
+    let base_dir = TempDir::new().unwrap();
+
+    let destination = base_dir.path().join("dir1/dir2");
+    let source = &destination.join("dir3");
+
+    DirBuilder::new().recursive(true).create(&source).expect("the source dir");
+
+    assert!(source.exists());
+    assert!(destination.exists());
+
+    setup_directory_structure(&source).expect("directory setup");
+    move_dir(&source, &destination).expect("successful move operation");
+    assert!(!source.exists());
+    assert_moved_structure_at(&destination)
+}
+
+#[test]
+fn move_dir_multiple_empty_level_up() {
+    let base_dir = TempDir::new().expect("a temp dir");
+
+    let destination = base_dir.path().join("dir1");
+    let middle = destination.join("dir2/dir3");
+    let source = middle.join("dir4");
+
+    DirBuilder::new().recursive(true).create(&source).expect("the source dir");
+
+    assert!(source.exists());
+    assert!(middle.exists());
+    assert!(destination.exists());
+
+    setup_directory_structure(&source).expect("directory setup");
+    move_dir(&source, &destination).expect("successful move operation");
+    assert!(!source.exists());
+    assert!(!middle.exists());
+    assert_moved_structure_at(&destination)
+}
+
+#[test]
+fn move_dir_multiple_non_empty_level_up() {
+    let base_dir = TempDir::new().unwrap();
+
+    let destination = base_dir.path().join("dir1");
+    let middle = destination.join("dir2/dir3");
+    let source = middle.join("dir4");
+
+    DirBuilder::new().recursive(true).create(&source).expect("the source dir");
+
+    assert!(source.exists());
+    assert!(middle.exists());
+    assert!(destination.exists());
+
+    setup_directory_structure(&source).expect("directory setup");
+    setup_directory_structure(&middle).expect("directory setup 2");
+
+    let result = move_dir(&source, &destination);
+
+    assert!(result.is_err());
+    //assert!(source.exists());
+}

--- a/uvm_move_dir/tests/rename_dir_tests.rs
+++ b/uvm_move_dir/tests/rename_dir_tests.rs
@@ -1,0 +1,69 @@
+mod helper;
+use self::helper::*;
+use uvm_move_dir::*;
+use std::fs::DirBuilder;
+use tempfile::TempDir;
+
+#[test]
+fn rename_directory_destination_does_not_exist() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("destination");
+
+    DirBuilder::new().recursive(true).create(&source).unwrap();
+
+    assert!(source.exists());
+    assert!(!destination.exists());
+
+    setup_directory_structure(&source).unwrap();
+    move_dir(&source, &destination).expect("successful move operation");
+
+    assert!(!source.exists());
+    assert!(destination.exists());
+    assert_moved_structure_at(&destination);
+}
+
+#[test]
+fn rename_directory_destination_does_exist() {
+
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("destination");
+
+    DirBuilder::new().recursive(true).create(&source).unwrap();
+    DirBuilder::new().recursive(true).create(&destination).unwrap();
+
+    assert!(source.exists());
+    assert!(destination.exists());
+
+    setup_directory_structure(&source).unwrap();
+    move_dir(&source, &destination).unwrap();
+
+    assert!(!source.exists());
+    assert!(destination.exists());
+    assert_moved_structure_at(&destination);
+}
+
+#[test]
+fn rename_directory_destination_does_exist_not_empty() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("destination");
+
+    DirBuilder::new().recursive(true).create(&source).unwrap();
+    DirBuilder::new().recursive(true).create(&destination).unwrap();
+
+    assert!(source.exists());
+    assert!(destination.exists());
+
+    setup_directory_structure(&source).unwrap();
+    setup_directory_structure(&destination).unwrap();
+    let result = move_dir(&source, &destination);
+
+    assert!(result.is_err());
+    assert!(source.exists());
+    assert!(destination.exists());
+}


### PR DESCRIPTION
## Description

`uvm_move_dir` contains opinionated directory move operations. Some of the new module installation processes require to move a directory into itself (e.g. `/foo/bar/baz` `->` `/foo/bar`). Most crates and even the std functions don't allow this. This crate tries to solve this in a non generic way. These methods are only intended for the specific use-case. A custom windows call is also provided to provide the same behavior as `std::fs::rename` when providing directories as `from` and `to`.

## Changes

![ADD] ![NEW] `uvm_move_dir` crate
![ADD] ![WINDOWS] special `rename` implementation.

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"