### PR TITLE
Improve uvm_move_dir input validation

### DIFF
--- a/uvm_move_dir/tests/rename_dir_tests.rs
+++ b/uvm_move_dir/tests/rename_dir_tests.rs
@@ -5,7 +5,7 @@ use std::fs::DirBuilder;
 use tempfile::TempDir;
 
 #[test]
-fn rename_directory_destination_does_not_exist() {
+fn rename_directory_when_destination_does_not_exist() {
     let base_dir = TempDir::new().unwrap();
 
     let source = base_dir.path().join("source");
@@ -25,7 +25,7 @@ fn rename_directory_destination_does_not_exist() {
 }
 
 #[test]
-fn rename_directory_destination_does_exist() {
+fn rename_directory_when_destination_exists_and_is_empty() {
 
     let base_dir = TempDir::new().unwrap();
 
@@ -47,7 +47,28 @@ fn rename_directory_destination_does_exist() {
 }
 
 #[test]
-fn rename_directory_destination_does_exist_not_empty() {
+fn fails_rename_when_from_is_not_a_directory() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("destination");
+
+    std::fs::File::create(&source).expect("a source as file");
+    DirBuilder::new().recursive(true).create(&destination).unwrap();
+
+    assert!(source.exists());
+    assert!(destination.exists());
+
+    let result = move_dir(&source, &destination);
+
+    assert!(result.is_err());
+    assert!(source.exists());
+    assert!(destination.exists());
+}
+
+
+#[test]
+fn fails_rename_directory_when_destination_exists_and_is_not_empty() {
     let base_dir = TempDir::new().unwrap();
 
     let source = base_dir.path().join("source");
@@ -61,6 +82,28 @@ fn rename_directory_destination_does_exist_not_empty() {
 
     setup_directory_structure(&source).unwrap();
     setup_directory_structure(&destination).unwrap();
+    let result = move_dir(&source, &destination);
+
+    assert!(result.is_err());
+    assert!(source.exists());
+    assert!(destination.exists());
+}
+
+#[test]
+fn fails_rename_directory_when_destination_exists_and_is_file() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("destination");
+
+    DirBuilder::new().recursive(true).create(&source).unwrap();
+    std::fs::File::create(&destination).expect("a destination as file");
+
+    assert!(source.exists());
+    assert!(destination.exists());
+    assert!(destination.is_file());
+
+    setup_directory_structure(&source).unwrap();
     let result = move_dir(&source, &destination);
 
     assert!(result.is_err());


### PR DESCRIPTION
## Description

This patch adds some input checks to fail early when source and destination paths are not directories.

## Changes

* ![IMPROVE] `uvm_move_dir` input validation

[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"