### PR TITLE
Fix missing move usecase

### DIFF
--- a/uvm_move_dir/src/lib.rs
+++ b/uvm_move_dir/src/lib.rs
@@ -72,6 +72,10 @@ pub fn move_dir<S: AsRef<Path>, D: AsRef<Path>>(source: S, destination: D) -> io
             fs::DirBuilder::new()
                 .recursive(true)
                 .create(destination)?;
+            #[cfg(windows)]
+            fs::DirBuilder::new()
+                .recursive(true)
+                .create(destination.parent().unwrap())?;
             #[cfg(unix)]
             fs::rename(source, destination)?;
             #[cfg(windows)]

--- a/uvm_move_dir/tests/move_dir_up_tests.rs
+++ b/uvm_move_dir/tests/move_dir_up_tests.rs
@@ -1,0 +1,65 @@
+mod helper;
+use self::helper::*;
+use uvm_move_dir::*;
+use std::fs::DirBuilder;
+use tempfile::TempDir;
+
+#[test]
+fn move_dir_one_level_down() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("middle/destination");
+
+    DirBuilder::new().recursive(true).create(&source).expect("the source dir");
+
+    assert!(source.exists());
+    assert!(!destination.exists());
+
+    setup_directory_structure(&source).expect("directory setup");
+
+    move_dir(&source, &destination).expect("successful move operation");
+    assert!(!source.exists());
+    assert_moved_structure_at(&destination)
+}
+
+#[test]
+fn move_dir_multiple_level_down() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("middle/middle2/destination");
+
+    DirBuilder::new().recursive(true).create(&source).expect("the source dir");
+
+    assert!(source.exists());
+    assert!(!destination.exists());
+
+    setup_directory_structure(&source).expect("directory setup");
+
+    move_dir(&source, &destination).expect("successful move operation");
+    assert!(!source.exists());
+    assert_moved_structure_at(&destination)
+}
+
+#[test]
+fn fails_move_dir_one_level_down_when_destination_exists() {
+    let base_dir = TempDir::new().unwrap();
+
+    let source = base_dir.path().join("source");
+    let destination = base_dir.path().join("middle/destination");
+
+    DirBuilder::new().recursive(true).create(&source).expect("the source dir");
+    DirBuilder::new().recursive(true).create(&destination).unwrap();
+
+    assert!(source.exists());
+    assert!(destination.exists());
+
+    setup_directory_structure(&source).unwrap();
+    setup_directory_structure(&destination).unwrap();
+    let result = move_dir(&source, &destination);
+
+    assert!(result.is_err());
+    assert!(source.exists());
+    assert!(destination.exists());
+}


### PR DESCRIPTION
## Description

The crate `uvm_move_dir` is missing a move use case.

source = `/path/to/dir`
destination = `/path/to/new/dir`

This patch adds the missing functionality for both Unix and windows.

## Changes

![FIX] missing move directory usecase

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
