### PR TITLE
Add windows long path support function

### DIFF
--- a/uvm_core/src/sys/win/installer.rs
+++ b/uvm_core/src/sys/win/installer.rs
@@ -4,6 +4,7 @@ use std::io::Write as IoWrite;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use tempfile::Builder;
+use crate::utils;
 
 pub fn install_editor<P, D>(
     installer: P,
@@ -16,9 +17,10 @@ where
 {
     let installer = installer.as_ref();
     let destination = match destination {
-        Some(ref d) => Some(d.as_ref()),
+        Some(ref d) => Some(utils::prepend_long_path_support(d)),
         _ => None,
     };
+    let destination = destination.as_ref();
 
     debug!("install editor {}", installer.display(),);
     if let Some(destination) = destination {
@@ -47,9 +49,10 @@ where
 {
     let installer = installer.as_ref();
     let destination = match destination {
-        Some(ref d) => Some(d.as_ref()),
+        Some(ref d) => Some(utils::prepend_long_path_support(d)),
         _ => None,
     };
+    let destination = destination.as_ref();
 
     debug!("install component {}", installer.display(),);
     if let Some(destination) = destination {


### PR DESCRIPTION
Description
============

To activate support for long path names I added a utility function which can be used to prepend a given path with a specific opt in prefix `\\?\` From the windows [docs][0]:

> For file I/O, the "\\?\" prefix to a path string tells the Windows APIs to disable all string parsing and to send the string that follows it straight to the file system. For example, if the file system supports large paths and file names, you can exceed the MAX_PATH limits that are otherwise enforced by the Windows APIs. For more information about the normal maximum path limitation, see the previous section Maximum Path Length Limitation.

More info can be found [here][0]

The windows installer functions call this new utility function and prefix all destination urls.

Changes
=======

* ![ADD] ![WINDOWS] long path support

[0]: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
