### PR TITLE
Fix modules install path

### DIFF
--- a/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.1.10f1_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.1.10f1_modules.json
@@ -300,7 +300,7 @@
     "visible": false,
     "sync": "android-sdk-ndk-tools",
     "selected": false,
-    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools",
+    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3",
     "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
   },
@@ -315,7 +315,7 @@
     "visible": false,
     "sync": "android-sdk-ndk-tools",
     "selected": false,
-    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms",
+    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28",
     "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
   },

--- a/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.2.0b9_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.2.0b9_modules.json
@@ -287,7 +287,7 @@
     "visible": false,
     "sync": "android-sdk-ndk-tools",
     "selected": false,
-    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools",
+    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3",
     "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
   },
@@ -302,7 +302,7 @@
     "visible": false,
     "sync": "android-sdk-ndk-tools",
     "selected": false,
-    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms",
+    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28",
     "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
   },

--- a/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.3.0a8_modules.json
+++ b/commands/uvm-generate-modules-json/tests/fixures/win/v2019/2019.3.0a8_modules.json
@@ -54,7 +54,7 @@
     "downloadSize": 52600000,
     "visible": false,
     "selected": false,
-    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools",
+    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3",
     "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
   },
@@ -82,7 +82,7 @@
     "downloadSize": 60600000,
     "visible": false,
     "selected": false,
-    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms",
+    "destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
     "renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28",
     "renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
   },

--- a/uvm_core/src/sys/linux/unity/component.rs
+++ b/uvm_core/src/sys/linux/unity/component.rs
@@ -33,8 +33,18 @@ pub fn installpath(component:Component) -> Option<PathBuf> {
     path.map(|p| Path::new(p).to_path_buf())
 }
 
-pub fn install_location(component:Component) -> Option<PathBuf> {
-    self::installpath(component)
+pub fn install_location(component: Component) -> Option<PathBuf> {
+    use Component::*;
+    let path = match component {
+        AndroidSdkPlatformTools => {
+            Some("PlaybackEngines/AndroidPlayer/SDK/platform-tools")
+        }
+        AndroidSdkNdkTools => {
+            Some("PlaybackEngines/AndroidPlayer/SDK/tools")
+        }
+        _ => None,
+    };
+    path.map(|p| Path::new(p).to_path_buf()).or_else(|| installpath(component))
 }
 
 pub fn selected(component:Component) -> bool {

--- a/uvm_core/src/sys/mac/unity/component.rs
+++ b/uvm_core/src/sys/mac/unity/component.rs
@@ -1,7 +1,7 @@
 use crate::unity::Component;
 use std::path::{Path, PathBuf};
 
-pub fn installpath(component:Component) -> Option<PathBuf> {
+pub fn installpath(component: Component) -> Option<PathBuf> {
     use Component::*;
     let path = match component {
         Mono | VisualStudio | FacebookGameRoom => None,
@@ -33,14 +33,24 @@ pub fn installpath(component:Component) -> Option<PathBuf> {
     path.map(|p| Path::new(p).to_path_buf())
 }
 
-pub fn install_location(component:Component) -> Option<PathBuf> {
-    self::installpath(component)
+pub fn install_location(component: Component) -> Option<PathBuf> {
+    use Component::*;
+    let path = match component {
+        AndroidSdkPlatformTools => {
+            Some("PlaybackEngines/AndroidPlayer/SDK/platform-tools")
+        }
+        AndroidSdkNdkTools => {
+            Some("PlaybackEngines/AndroidPlayer/SDK/tools")
+        }
+        _ => None,
+    };
+    path.map(|p| Path::new(p).to_path_buf()).or_else(|| installpath(component))
 }
 
-pub fn selected(component:Component) -> bool {
+pub fn selected(component: Component) -> bool {
     use Component::*;
     match component {
         MonoDevelop | Documentation | ExampleProject | Example | VisualStudio => true,
-        _ => false
+        _ => false,
     }
 }

--- a/uvm_core/src/sys/win/unity/component.rs
+++ b/uvm_core/src/sys/win/unity/component.rs
@@ -3,17 +3,24 @@ use std::path::{Path, PathBuf};
 
 pub enum InstallerType {
     Exe,
-    Zip
+    Zip,
 }
 
-pub fn installpath(component:Component, installer_type:InstallerType) -> Option<PathBuf> {
+pub fn installpath(component: Component, installer_type: InstallerType) -> Option<PathBuf> {
     use Component::*;
     use InstallerType::*;
     match installer_type {
         Exe => {
             let path = match component {
-                VisualStudio | ExampleProject | Example | FacebookGameRoom | VisualStudioProfessionalUnityWorkload | VisualStudioEnterpriseUnityWorkload => None,
-                AndroidSdkPlatformTools | AndroidSdkNdkTools => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK"),
+                VisualStudio
+                | ExampleProject
+                | Example
+                | FacebookGameRoom
+                | VisualStudioProfessionalUnityWorkload
+                | VisualStudioEnterpriseUnityWorkload => None,
+                AndroidSdkPlatformTools | AndroidSdkNdkTools => {
+                    Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK")
+                }
                 AndroidSdkBuildTools => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK"),
                 AndroidSdkPlatforms => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK"),
                 AndroidNdk => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\NDK"),
@@ -24,33 +31,55 @@ pub fn installpath(component:Component, installer_type:InstallerType) -> Option<
 
             path.map(|p| Path::new(p).to_path_buf())
         }
-        Zip => install_location(component)
+        Zip => {
+            let path = match component {
+                AndroidSdkPlatforms
+                | AndroidSdkBuildTools
+                | AndroidSdkPlatformTools
+                | AndroidSdkNdkTools => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK"),
+                _ => None,
+            };
+
+            path.map(|p| Path::new(p).to_path_buf()).or_else(|| install_location(component))
+        }
     }
 }
 
-pub fn install_location(component:Component) -> Option<PathBuf> {
+pub fn install_location(component: Component) -> Option<PathBuf> {
     use Component::*;
     let path = match component {
-        VisualStudio | ExampleProject | Example | FacebookGameRoom | VisualStudioProfessionalUnityWorkload | VisualStudioEnterpriseUnityWorkload => None,
+        VisualStudio
+        | ExampleProject
+        | Example
+        | FacebookGameRoom
+        | VisualStudioProfessionalUnityWorkload
+        | VisualStudioEnterpriseUnityWorkload => None,
         Mono | MonoDevelop => Some(r""),
         Documentation => Some(r"Editor\Data"),
         StandardAssets => Some(r"Editor"),
         Android => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer"),
         AndroidSdkBuildTools => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK\build-tools"),
         AndroidSdkPlatforms => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK\platforms"),
-        AndroidSdkPlatformTools | AndroidSdkNdkTools => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK"),
+        AndroidSdkPlatformTools => {
+            Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK\platform-tools")
+        }
+        AndroidSdkNdkTools => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\SDK\tools"),
         AndroidNdk => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\NDK"),
         AndroidOpenJdk => Some(r"Editor\Data\PlaybackEngines\AndroidPlayer\OpenJDK"),
         Ios => Some(r"Editor\Data\PlaybackEngines\iOSSupport"),
         TvOs | AppleTV => Some(r"Editor\Data\PlaybackEngines\AppleTVSupport"),
         Linux | LinuxMono => Some(r"Editor\Data\PlaybackEngines\LinuxStandaloneSupport"),
         Mac | MacIL2CPP | MacMono => Some(r"Editor\Data\PlaybackEngines\MacStandaloneSupport"),
-        Metro | UwpIL2CPP | UwpNet | UniversalWindowsPlatform => Some(r"Editor\Data\PlaybackEngines\MetroSupport"),
+        Metro | UwpIL2CPP | UwpNet | UniversalWindowsPlatform => {
+            Some(r"Editor\Data\PlaybackEngines\MetroSupport")
+        }
         Samsungtv | SamsungTV => Some(r"Editor\Data\PlaybackEngines\STVPlayer"),
         Tizen => Some(r"Editor\Data\PlaybackEngines\TizenPlayer"),
         Vuforia | VuforiaAR => Some(r"Editor\Data\PlaybackEngines\VuforiaSupport"),
         WebGl => Some(r"Editor\Data\PlaybackEngines\WebGLSupport"),
-        Windows | WindowsMono | WindowsIL2CCP => Some(r"Editor\Data\PlaybackEngines\WindowsStandaloneSupport"),
+        Windows | WindowsMono | WindowsIL2CCP => {
+            Some(r"Editor\Data\PlaybackEngines\WindowsStandaloneSupport")
+        }
         Facebook | FacebookGames => Some(r"Editor\Data\PlaybackEngines\Facebook"),
         Lumin => None,
         Language(_) => Some(r"Editor\Data\Localization"),
@@ -60,10 +89,10 @@ pub fn install_location(component:Component) -> Option<PathBuf> {
     path.map(|p| Path::new(p).to_path_buf())
 }
 
-pub fn selected(component:Component) -> bool {
+pub fn selected(component: Component) -> bool {
     use Component::*;
     match component {
         Documentation | StandardAssets | ExampleProject | Example | VisualStudio => true,
-        _ => false
+        _ => false,
     }
 }


### PR DESCRIPTION
## Description

I realized that some of the installpath and install_location returns were incorrect when compared to the offical `modules.json` files coming from Unity.

Example:

_macOS android-sdk-build-tools_

```json
"destination": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools",
"renameTo": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools/28.0.3",
"renameFrom": "{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools/android-9"
```

_windows android-sdk-build-tools_

```json
"destination": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK",
"renameTo": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platforms/android-28",
"renameFrom": "{UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/android-9"
```

The difference is marginal and yields a similar installation path. But I made a mistake coping the macOS values over to windows and adjusted some values based on the expected windows output path. Classic problem. Never trust your own fixtures.

Since I want to produce the same `modules.json` files as Unity Hub and the modules in questions are not part of the older `ini` manifest files I had to fix this.

I also took this chance of adjusting the `install_location` return types slightly. In most cases the install path and `install_location` is the same and or unique enough to just probe for the existence of the directory to determine if something is installed or not. In case of `android` it is not. The `destination` field points in some cases to a shared location (`PlaybackEngines/AndroidPlayer/SDK`) even though the final resources are located in a subdirectory. This was never a problem
because modules always had a unique install path. I took the liberty to manually adjust this path for installation checks for now.
Means:

macOS _android-sdk-build-tools_:
* installpath `->` `{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK`
* install_location `->` `{UNITY_PATH}/PlaybackEngines/AndroidPlayer/SDK/build-tools`

I hope this solution works until I have time to implement a check to ask the `modules.json` if a given module is installed or not.

## Changes

* ![FIX] ![WINDOWS] module install path
* ![IMPROVE] module `install_location` path

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
