### PR TITLE
Add new install command uvm_install2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,12 @@ matrix:
     - env: TARGET=x86_64-apple-darwin
       os: osx
 
+    - env:
+      - TARGET=x86_64-apple-darwin
+      - INSTALLER_TESTS=1
+      - RUST_LOG="warn,uvm_core=info,uvm_install2=info"
+      os: osx
+
     # # *BSD
     # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +218,20 @@ dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -464,6 +486,18 @@ version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1524,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1599,6 +1633,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1614,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1647,11 +1686,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termios"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "test-env-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1967,7 +2033,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uvm_cli 2.0.1",
  "uvm_core 0.5.0",
@@ -2040,6 +2105,25 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "uvm_cli 2.0.1",
  "uvm_core 0.5.0",
+]
+
+[[package]]
+name = "uvm-install2"
+version = "0.1.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-2 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flexi_logger 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-env-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_core 0.5.0",
+ "uvm_install_graph 0.1.0",
+ "uvm_move_dir 0.1.0",
 ]
 
 [[package]]
@@ -2176,8 +2260,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm_move_dir"
+version = "0.1.0"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2243,9 +2342,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winreg"
@@ -2301,6 +2417,7 @@ dependencies = [
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
@@ -2325,6 +2442,7 @@ dependencies = [
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cli_core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ce2a4fed13508c92ba7afb5ad9a43b315614498d09366cc29c41d43108ab34"
 "checksum clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f84dec9bc083ce2503908cd305af98bd363da6f54bf8d4bf0ac14ee749ad5d1"
 "checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
@@ -2352,6 +2470,7 @@ dependencies = [
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
+"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -2484,12 +2603,16 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum stringreader 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "913e7b03d63752f6cdd2df77da36749d82669904798fe8944b9ec3d23f159905"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
+"checksum test-env-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "515962a8c9b1d057f433695cb76db04a4d3d408247a21da9ba3af72fa23c318a"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
@@ -2517,6 +2640,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
@@ -2527,7 +2651,9 @@ dependencies = [
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,18 +9,18 @@ main() {
       cargo=cross
     fi
 
-    $cargo build --target $TARGET
     $cargo build --target $TARGET --release
 
     if [ ! -z $DISABLE_TESTS ]; then
         return
     fi
 
-    $cargo test --target $TARGET --release
-    $cargo test --target $TARGET
-
-    $cargo run --target $TARGET --bin uvm -- --help
-    $cargo run --target $TARGET --bin uvm --release -- --help
+    if [ ! -z $INSTALLER_TESTS ]; then
+      $cargo test installs_editor_and_modules_ --target $TARGET --release -- --nocapture --ignored
+    else
+      $cargo test --target $TARGET --release
+      $cargo run --target $TARGET --bin uvm --release -- --help
+    fi
  }
 
 # we don't run the "test phase" when doing deploys

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uvm-install2"
+version = "0.1.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+edition = "2018"
+
+[dependencies]
+clap = {version = "2.33.0", features = ["suggestions", "color"]}
+console = "0.9.0"
+error-chain = "0.12.0"
+flexi_logger = "0.14.4"
+indicatif = "0.12.0"
+log = "0.4.5"
+dirs-2 = "1.1.0"
+uvm_core = { path = "../../uvm_core", version = "0.5.0" }
+uvm_install_graph = { path = "../../uvm_install_graph", version = "0.1.0" }
+uvm_move_dir = {path = "../../uvm_move_dir"}
+
+[dev-dependencies]
+tempfile = "3.1.0"
+test-env-log = "0.1.1"
+env_logger = "0.7"

--- a/install/uvm-install2/src/error.rs
+++ b/install/uvm-install2/src/error.rs
@@ -1,0 +1,13 @@
+use error_chain::error_chain;
+use uvm_core::install::error as install_error;
+error_chain! {
+    links {
+        UvmError(uvm_core::error::UvmError, uvm_core::error::UvmErrorKind);
+        UvmInstallError(install_error::UvmInstallError, install_error::UvmInstallErrorKind);
+    }
+
+    foreign_links {
+        Fmt(::std::fmt::Error);
+        Io(::std::io::Error);
+    }
+}

--- a/install/uvm-install2/src/main.rs
+++ b/install/uvm-install2/src/main.rs
@@ -1,0 +1,140 @@
+use std::error::Error;
+use console::style;
+use clap::{arg_enum, crate_authors, crate_version, value_t, values_t, App, Arg};
+use console::Style;
+use flexi_logger::DeferredNow;
+use flexi_logger::{Level, LevelFilter, LogSpecification, Logger, Record};
+use std::io;
+use log::*;
+use std::path::PathBuf;
+use std::process;
+use uvm_core::unity::Component;
+use uvm_core::unity::Version;
+
+fn main() {
+    let matches = App::new("uvm-install2")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("Install specified unity version.")
+        .arg(
+            Arg::with_name("module")
+                .help("Module to install")
+                .long_help(
+                    "A support module to install. You can list all awailable
+modules for a given version using `uvm-modules`",
+                )
+                .long("module")
+                .short("m")
+                .takes_value(true)
+                .number_of_values(1)
+                .multiple(true),
+        )
+        .arg(
+            Arg::with_name("version")
+                .help("The unity version to install in the form of `2018.1.0f3`")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("destination")
+                .help("A directory to install the requested version to")
+                .required(false)
+                .index(2),
+        )
+        .arg(
+            Arg::with_name("debug")
+                .help("print debug output")
+                .long("debug")
+                .short("d"),
+        )
+        .arg(
+            Arg::with_name("sync")
+                .help("install also synced modules")
+                .long("with-sync"),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .help("print more output")
+                .long("verbose")
+                .short("v"),
+        )
+        .arg(
+            Arg::with_name("color")
+                .help("Coloring")
+                .long("color")
+                .takes_value(true)
+                .possible_values(&["auto", "always", "never"])
+                .default_value("auto"),
+        )
+        .get_matches();
+
+    let version = value_t!(matches, "version", Version).unwrap();
+    let destination = value_t!(matches, "destination", PathBuf).ok();
+    let modules = values_t!(matches, "module", Component).ok();
+        // .unwrap_or_else(|_| vec![Component::Editor]);
+
+    let install_sync = matches.is_present("sync");
+
+    match value_t!(matches, "color", ColorOption).unwrap() {
+        ColorOption::Never => console::set_colors_enabled(false),
+        ColorOption::Always => console::set_colors_enabled(true),
+        ColorOption::Auto => (),
+    };
+
+    let mut log_spec_builder = LogSpecification::default(LevelFilter::Warn);
+    let log_spec_builder = if matches.is_present("debug") {
+        log_spec_builder
+            .module("uvm_core", LevelFilter::Trace)
+            .module("uvm_install2", LevelFilter::Trace)
+    } else if matches.is_present("verbose") {
+        log_spec_builder
+            .module("uvm_core", LevelFilter::Info)
+            .module("uvm_install2", LevelFilter::Info)
+    } else {
+        log_spec_builder
+        .module("uvm_core", LevelFilter::Warn)
+        .module("uvm_install2", LevelFilter::Warn)
+    };
+
+    let log_spec = log_spec_builder.build();
+    Logger::with(log_spec).format(format_logs).start().unwrap();
+
+    uvm_install2::install(version, modules.as_ref(), install_sync, destination).unwrap_or_else(|err| {
+        let message = "Failure during installation";
+        eprintln!("{}", style(message).red());
+        info!("{}", &format!("{}", style(&err).red()));
+        if let Some(source) = err.source() {
+            info!("{}", &format!("{}", style(source).red()));
+        }
+        process::exit(1);
+    });
+
+    eprintln!("{}", style("Finish").green().bold())
+}
+
+arg_enum! {
+    #[derive(PartialEq, Debug)]
+    pub enum ColorOption {
+        Auto,
+        Always,
+        Never,
+    }
+}
+
+fn format_logs(
+    writer: &mut dyn io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), io::Error> {
+    let style = match record.level() {
+        Level::Trace => Style::new().white().dim().italic(),
+        Level::Debug => Style::new().white().dim(),
+        Level::Info => Style::new().white(),
+        Level::Warn => Style::new().yellow(),
+        Level::Error => Style::new().red(),
+    };
+
+    writer
+        .write(&format!("{}", style.apply_to(record.args())).into_bytes())
+        .map(|_| ())
+}

--- a/install/uvm-install2/tests/install_tests.rs
+++ b/install/uvm-install2/tests/install_tests.rs
@@ -1,0 +1,86 @@
+use env_logger;
+use std::collections::HashSet;
+use tempfile;
+use test_env_log::test;
+use uvm_core::unity::{Component, Installation, Version};
+
+#[cfg(target_os = "macos")]
+#[ignore]
+#[test]
+fn installs_editor_2019_3() {
+    let version = Version::b(2019, 3, 0, 7);
+    let destination = tempfile::tempdir().unwrap();
+    let result = uvm_install2::install(
+        &version,
+        Option::<Vec<Component>>::None,
+        false,
+        Some(&destination),
+    );
+    assert!(result.is_ok());
+
+    Installation::new(destination).expect("a unity installation");
+}
+
+#[cfg(target_os = "macos")]
+#[ignore]
+#[test]
+fn installs_editor_and_modules_2019_3_with_android_and_sync_modules() {
+    use Component::*;
+    let version = Version::b(2019, 3, 0, 8);
+    let destination = tempfile::tempdir().unwrap();
+    let components: HashSet<Component> = [Android].into_iter().map(|c| *c).collect();
+    let result = uvm_install2::install(&version, Some(&components), true, Some(&destination));
+
+    assert!(result.is_ok());
+
+    let installation = Installation::new(&destination).expect("a unity installation");
+    let installed_components: HashSet<Component> = installation.installed_components().collect();
+    let expected_components: HashSet<Component> = [
+        Android,
+        AndroidOpenJdk,
+        AndroidNdk,
+        AndroidSdkNdkTools,
+        AndroidSdkBuildTools,
+        AndroidSdkPlatformTools,
+    ]
+    .into_iter()
+    .map(|c| *c)
+    .collect();
+    println!("{:?}", installed_components);
+    assert!(installed_components.is_superset(&components));
+}
+
+#[cfg(target_os = "macos")]
+#[ignore]
+#[test]
+fn installs_editor_2018_4() {
+    let version = Version::f(2018, 4, 12, 1);
+    let destination = tempfile::tempdir().unwrap();
+    let result = uvm_install2::install(
+        &version,
+        Option::<Vec<Component>>::None,
+        false,
+        Some(&destination),
+    );
+    assert!(result.is_ok());
+
+    Installation::new(destination).expect("a unity installation");
+}
+
+#[cfg(target_os = "macos")]
+#[ignore]
+#[test]
+fn installs_editor_and_modules_2018_4_with_ios_android_webgl() {
+    let version = Version::f(2018, 4, 11, 1);
+    let destination = tempfile::tempdir().unwrap();
+    let components: HashSet<Component> = [Component::Ios, Component::Android, Component::WebGl]
+        .into_iter()
+        .map(|c| *c)
+        .collect();
+    let result = uvm_install2::install(&version, Some(&components), false, Some(&destination));
+    assert!(result.is_ok());
+
+    let installation = Installation::new(&destination).expect("a unity installation");
+    let installed_components: HashSet<Component> = installation.installed_components().collect();
+    assert!(installed_components.is_superset(&components));
+}


### PR DESCRIPTION
## Description

This patch brings in a complete new installer. It's a first step for an installer that manages to be fully compatible with all unity module types. The command line interface is very different compared to the original `uvm-install` command. Modules have to be references by `id` instead of commandline flags. It becomes impossible to keep a list of possible flags when each version of unity changes names/numbers of modules. The helper task `uvm-modules` should be used to fetch a list of available modules for a given unity version.

### Usage

```
USAGE:
    uvm-install2 [FLAGS] [OPTIONS] <version> [--] [destination]

FLAGS:
    -d, --debug
            print debug output

    -h, --help
            Prints help information

        --with-sync
            install also synced modules

    -V, --version
            Prints version information

    -v, --verbose
            print more output


OPTIONS:
        --color <color>
            Coloring [default: auto]  [possible values: auto, always, never]

    -m, --module <module>...
            A support module to install. You can list all awailable
            modules for a given version using `uvm-modules`

ARGS:
    <version>
            The unity version to install in the form of `2018.1.0f3`

    <destination>
            A directory to install the requested version to
```

The new command is written with [`clap`] instead of [`docopt`] to check out if this way of declaring the command line interface is more natural.

The command itself will be slower compared then the old one because it installs the requested unity version and modules sequentially. The plan is to address this after verifying that the new installer actually works like intended.

## Changes

* ![ADD] ![NEW] installer `uvm-install2`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"

[`clap`]:  https://crates.io/crates/clap
[`docopt`]:  https://crates.io/crates/docopt
