### PR TITLE
Add AsRef<Component> iml for Component and Module

### DIFF
--- a/uvm_core/src/unity/component/mod.rs
+++ b/uvm_core/src/unity/component/mod.rs
@@ -263,6 +263,12 @@ impl Component {
     }
 }
 
+impl AsRef<Component> for Component {
+    fn as_ref(&self) -> &Component {
+        self
+    }
+}
+
 impl Default for Component {
     fn default() -> Self {
         Component::Editor

--- a/uvm_core/src/unity/version/module.rs
+++ b/uvm_core/src/unity/version/module.rs
@@ -125,6 +125,12 @@ impl Ord for Module {
     }
 }
 
+impl AsRef<Component> for Module {
+    fn as_ref(&self) -> &Component {
+        &self.id
+    }
+}
+
 impl Module {
     #[cfg(not(windows))]
     fn destination(component: Component, _: &str) -> Option<PathBuf> {


### PR DESCRIPTION
## Description

A simple patch that adds `AsRef<Component>` implementations for both `uvm_core::unity::Component` and `uvm_core::unity::Module`.

## Changes

* ![ADD] `AsRef<Component>` impl for `uvm_core::unity::Component`
* ![ADD] `AsRef<Component>` impl for `uvm_core::unity::Module`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
