### PR TITLE
Fix add installation to unity hub editors list

### DIFF
--- a/install/uvm-install2/tests/install_tests.rs
+++ b/install/uvm-install2/tests/install_tests.rs
@@ -19,6 +19,8 @@ fn installs_editor_2019_3() {
     assert!(result.is_ok());
 
     Installation::new(destination).expect("a unity installation");
+    uvm_core::find_installation(&version)
+        .expect("a unity installation from unity hub editors list");
 }
 
 #[cfg(target_os = "macos")]
@@ -28,7 +30,7 @@ fn installs_editor_and_modules_2019_3_with_android_and_sync_modules() {
     use Component::*;
     let version = Version::b(2019, 3, 0, 8);
     let destination = tempfile::tempdir().unwrap();
-    let components: HashSet<Component> = [Android].into_iter().map(|c| *c).collect();
+    let components: HashSet<Component> = [Android].iter().copied().collect();
     let result = uvm_install2::install(&version, Some(&components), true, Some(&destination));
 
     assert!(result.is_ok());
@@ -43,11 +45,14 @@ fn installs_editor_and_modules_2019_3_with_android_and_sync_modules() {
         AndroidSdkBuildTools,
         AndroidSdkPlatformTools,
     ]
-    .into_iter()
-    .map(|c| *c)
+    .iter()
+    .copied()
     .collect();
     println!("{:?}", installed_components);
     assert!(installed_components.is_superset(&expected_components));
+
+    uvm_core::find_installation(&version)
+        .expect("a unity installation from unity hub editors list");
 }
 
 #[cfg(target_os = "macos")]
@@ -65,6 +70,9 @@ fn installs_editor_2018_4() {
     assert!(result.is_ok());
 
     Installation::new(destination).expect("a unity installation");
+
+    uvm_core::find_installation(&version)
+        .expect("a unity installation from unity hub editors list");
 }
 
 #[cfg(target_os = "macos")]
@@ -74,8 +82,8 @@ fn installs_editor_and_modules_2018_4_with_ios_android_webgl() {
     let version = Version::f(2018, 4, 11, 1);
     let destination = tempfile::tempdir().unwrap();
     let components: HashSet<Component> = [Component::Ios, Component::Android, Component::WebGl]
-        .into_iter()
-        .map(|c| *c)
+        .iter()
+        .copied()
         .collect();
     let result = uvm_install2::install(&version, Some(&components), false, Some(&destination));
     assert!(result.is_ok());
@@ -83,4 +91,7 @@ fn installs_editor_and_modules_2018_4_with_ios_android_webgl() {
     let installation = result.unwrap();
     let installed_components: HashSet<Component> = installation.installed_components().collect();
     assert!(installed_components.is_superset(&components));
+
+    uvm_core::find_installation(&version)
+        .expect("a unity installation from unity hub editors list");
 }


### PR DESCRIPTION
## Description

Whenever a installation destination is set to a custom directory, the installer should add the installation to the unity hub editors list. The old installer did this. I added the missing lines of code and updated the tests.

## Changes

* ![FIX] add installation to unity hub editors list

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
