### PR TITLE
Fix prepend windows long path during module move

### DIFF
--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -226,6 +226,12 @@ fn install_module_and_dependencies<P: AsRef<Path>>(
                 let module = graph.manifest().get(&component).unwrap();
                 if let Some((from, to)) = module.install_rename_from_to(&base_dir) {
                     info!("move {} to {}", from.display(), to.display());
+
+                    #[cfg(windows)]
+                    let from = uvm_core::utils::prepend_long_path_support(from);
+                    #[cfg(windows)]
+                    let to = uvm_core::utils::prepend_long_path_support(to);
+
                     move_dir(&from, &to)?;
                 }
             }


### PR DESCRIPTION
## Description

The move operation of certain modules can fail if the path is longer  than `PATH_MAX`. This patch adds the long path prefix on windows before executing the move.

## Changes

* ![FIX] prepend windows long path

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
