### PR TITLE
Fix try to create temp dir on same disk volume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ dependencies = [
  "test-env-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uvm_core 0.6.2",
  "uvm_install_graph 0.2.0",
- "uvm_move_dir 0.1.0",
+ "uvm_move_dir 0.1.1",
 ]
 
 [[package]]
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "uvm_move_dir"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/uvm_move_dir/Cargo.toml
+++ b/uvm_move_dir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm_move_dir"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 description = "Opinionated directory move operation"
 repository = "https://github.com/Larusso/unity-version-manager"


### PR DESCRIPTION
## Descrition

This is a desperate attempt to mitigate issues when both source anddestination are on different volumes than the default temp location. This issue should be fixed by copying files rather rename directories twice. On windows this could be handled with an option flag.

## Changes

![FIX] try to create temp dir on same disk volume

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
[WINDOWS]:https://atlas-resources.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]::https://atlas-resources.wooga.com/icons/icon_iOS.svg "MacOs"
