### PR TITLE
Remove i686-apple-darwin build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,6 @@ matrix:
     # - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
-    - env: TARGET=i686-apple-darwin
-      os: osx
     - env: TARGET=x86_64-apple-darwin
       os: osx
 


### PR DESCRIPTION
## Description

The `i686-apple-darwin` is no longer a first tier support target and is
no longer needed.
