### PR TITLE
Fix missing install process lock for install2 command

### DIFF
--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm-install2"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 description = "A unity3d installer"
 repository = "https://github.com/Larusso/unity-version-manager"

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -12,6 +12,8 @@ use uvm_install_core::create_installer;
 use uvm_install_graph::{InstallGraph, InstallStatus, Walker};
 pub mod error;
 use uvm_install_core::Loader;
+use std::fs;
+use uvm_core::unity::hub::paths;
 
 fn print_graph(graph: &InstallGraph) {
     use console::Style;
@@ -59,6 +61,13 @@ where
     I::Item: AsRef<Component>,
 {
     let version = version.as_ref();
+    let locks_dir = paths::locks_dir().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "Unable to locate locks directory.")
+    })?;
+
+    fs::DirBuilder::new().recursive(true).create(&locks_dir)?;
+    lock_process!(locks_dir.join(format!("{}.lock", version)));
+
     let mut manifest = Manifest::load(version)?;
     let mut graph = InstallGraph::from(&manifest);
 


### PR DESCRIPTION
## Description

The `install2` command was not locking the install process for the given version like the old implementation does. That results in some buggy behavior when two processes of uvm install2 try to install or alter the same unity installation.

The patch simply locks the whole install method if another process is trying to alter the Unity installation for a given version. This means even parallel calls of `install` and `install2` should be covered.

## Changes

* ![FIX] missing install process lock for `install2` command


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"