### PR TITLE
Improve uvm-list command defaults listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "uvm-list"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "console 0.9.1",

--- a/commands/uvm-list/Cargo.toml
+++ b/commands/uvm-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm-list"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 edition = "2018"
 description = "List installed unity versions"

--- a/commands/uvm-list/src/main.rs
+++ b/commands/uvm-list/src/main.rs
@@ -21,13 +21,17 @@ struct Opts {
     #[structopt(short, long)]
     debug: bool,
 
-    /// print unity hub installations
+    /// print unity hub installations [default listing]
     #[structopt(long = "hub")]
     use_hub: bool,
 
     /// print all unity installations
     #[structopt(long)]
     all: bool,
+
+    /// print unity installations at default installation location
+    #[structopt(long)]
+    system: bool,
 
     /// Color:.
     #[structopt(short, long, possible_values = &ColorOption::variants(), case_insensitive = true, default_value)]
@@ -47,15 +51,15 @@ fn main() -> Result<()> {
 
 fn list(options: &Opts) -> io::Result<()> {
     let current_version = uvm_core::current_installation().ok();
-    let list_function = if options.all {
+    let list_function = if options.system {
+        info!("fetch system installations");
+        uvm_core::list_installations
+    } else if options.all {
         info!("fetch all installations");
         uvm_core::list_all_installations
-    } else if options.use_hub {
+    } else {
         info!("fetch installations from unity hub");
         uvm_core::list_hub_installations
-    } else {
-        info!("fetch installations from uvm");
-        uvm_core::list_installations
     };
 
     if let Ok(installations) = list_function() {


### PR DESCRIPTION
##Description

The `uvm-list` command used to print the default uvm installations as a default. These are installations from the default system installation location.

windows: `c:\program files\`
macOS: `/Applications`
linux: `$HOME/.local/bin`

This makes no real sense as a default since uvm installs by default to the unity hub configured locations. So the default listing is now the `--hub` listing.