### PR TITLE
Fix unwrap panic during install with unsupported modules

### DIFF
--- a/install/uvm-install2/src/error.rs
+++ b/install/uvm-install2/src/error.rs
@@ -9,4 +9,11 @@ error_chain! {
         Fmt(::std::fmt::Error);
         Io(::std::io::Error);
     }
+
+    errors {
+        UnsupportedModuleError(c: String, v:String) {
+            description("unsupported unity module for unity version"),
+            display("unsupported module: '{}' for selected unity version {}", c, v),
+        }
+    }
 }


### PR DESCRIPTION
## Description

The install2 `install` function panics when one or more modules are selected, which are not compatible with the selected unity version to install. The component enum values are not save to use over all versions of unity. This can only be determined at runtime. The old implementation did a simple unwrap and panicked. I rewrote the logic to yield a `Result<HashSet<Component>>` instead.