### PR TITLE
Fix error print in --help messages.

### DIFF
--- a/commands/uvm-detect/src/main.rs
+++ b/commands/uvm-detect/src/main.rs
@@ -6,18 +6,24 @@ use uvm_core;
 use console::style;
 use std::env;
 use std::path::PathBuf;
-use structopt::{clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
+use structopt::{
+    clap::crate_authors, clap::crate_description, clap::crate_version, clap::AppSettings, StructOpt,
+};
 use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
 
-#[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
-struct Opts {
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
 
-    /// path to project directory. 
+#[derive(StructOpt, Debug)]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
+struct Opts {
+    /// path to project directory.
     project_path: Option<PathBuf>,
 
     /// Detects a unity version recursivly from current working directory.
-    /// With this flag set, the tool returns the first version it finds. 
+    /// With this flag set, the tool returns the first version it finds.
     #[structopt(short, long)]
     recursive: bool,
 
@@ -35,16 +41,16 @@ struct Opts {
 }
 
 fn main() -> Result<()> {
-  let opt = Opts::from_args_safe().map(|opt| {
-      set_colors_enabled(&opt.color);
-      set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
-      opt
-  })?;
+    let opt = Opts::from_args();
 
-  let project_version = uvm_core::dectect_project_version(
+    set_colors_enabled(&opt.color);
+    set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
+
+    let project_version = uvm_core::dectect_project_version(
         &opt.project_path.unwrap_or(env::current_dir()?),
-        Some(opt.recursive))?;
+        Some(opt.recursive),
+    )?;
 
-  println!("{}", style(project_version.to_string()).green().bold());
-  Ok(())
+    println!("{}", style(project_version.to_string()).green().bold());
+    Ok(())
 }

--- a/commands/uvm-help/src/main.rs
+++ b/commands/uvm-help/src/main.rs
@@ -1,9 +1,14 @@
 use anyhow::{Context, Result};
-use structopt::{clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
+use structopt::{clap::AppSettings, clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
 use uvm_cli;
 
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
+
 #[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
 struct Opts {
     /// Command name to print help text for
     command: String,

--- a/commands/uvm-launch/src/main.rs
+++ b/commands/uvm-launch/src/main.rs
@@ -6,12 +6,18 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
 use structopt::{
-    clap::arg_enum, clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt,
+    clap::arg_enum, clap::crate_authors, clap::crate_description, clap::crate_version,
+    clap::AppSettings, StructOpt,
 };
 use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
 
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
+
 #[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
 struct Opts {
     /// the build platform to open the project with
     #[structopt(short, long, possible_values = &UnityPlatform::variants(), case_insensitive = true)]
@@ -42,7 +48,7 @@ fn main() -> Result<()> {
     let opt = Opts::from_args();
     set_colors_enabled(&opt.color);
     set_loglevel(opt.verbose);
-    
+
     launch(&opt).context("failed to launch Unity")?;
     Ok(())
 }

--- a/commands/uvm-list/src/main.rs
+++ b/commands/uvm-list/src/main.rs
@@ -2,12 +2,19 @@ use anyhow::{Context, Result};
 use console::Style;
 use log::info;
 use std::io;
-use structopt::{clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
+use structopt::{
+    clap::crate_authors, clap::crate_description, clap::crate_version, clap::AppSettings, StructOpt,
+};
 use uvm_cli;
 use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
 
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
+
 #[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
 struct Opts {
     /// print only the path to the current version
     #[structopt(short, long = "path")]
@@ -39,11 +46,10 @@ struct Opts {
 }
 
 fn main() -> Result<()> {
-    let opt = Opts::from_args_safe().map(|opt| {
-        set_colors_enabled(&opt.color);
-        set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
-        opt
-    })?;
+    let opt = Opts::from_args();
+
+    set_colors_enabled(&opt.color);
+    set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
 
     list(&opt).context("failed to list Unity installations")?;
     Ok(())

--- a/install/uvm-install2/src/main.rs
+++ b/install/uvm-install2/src/main.rs
@@ -1,35 +1,42 @@
+use self::error;
 use console::style;
-use std::io::{self, Write};
 use log::*;
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
+use structopt::{
+    clap::crate_authors, clap::crate_description, clap::crate_version, clap::AppSettings, StructOpt,
+};
+use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
 use uvm_core::unity::Component;
 use uvm_core::unity::Version;
-use structopt::{clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
-use self::error;
-use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
+
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
 
 #[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
 struct Opts {
     /// Module to install
-    /// 
+    ///
     /// A support module to install. You can list all awailable
-    /// modules for a given version using `uvm-modules` 
+    /// modules for a given version using `uvm-modules`
     #[structopt(short, long = "module", number_of_values = 1)]
     modules: Option<Vec<Component>>,
 
     /// Install also synced modules
-    /// 
+    ///
     /// Synced modules are optional dependencies of some Unity modules.
-    /// e.g. Android SDK for the android module. 
+    /// e.g. Android SDK for the android module.
     #[structopt(long = "with-sync")]
     sync: bool,
 
     /// The unity version to install in the form of `2018.1.0f3`
     version: Version,
 
-    /// A directory to install the requested version to 
+    /// A directory to install the requested version to
     destination: Option<PathBuf>,
 
     /// print debug output
@@ -46,33 +53,31 @@ struct Opts {
 }
 
 fn main() {
-    let opt = Opts::from_args_safe().map(|opt| {
-        set_colors_enabled(&opt.color);
-        set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
-        opt
-    }).map_err(|e| {
-        eprintln!("{}", e.message);
-        process::exit(1); 
-    }).unwrap();
+    let opt = Opts::from_args();
+
+    set_colors_enabled(&opt.color);
+    set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
 
     let version = opt.version;
     let modules = opt.modules;
     let install_sync = opt.sync;
     let destination = opt.destination;
 
-    uvm_install2::install(version, modules.as_ref(), install_sync, destination).unwrap_or_else(|err| {
-        error!("Failure during installation");
-        error!("{}", &err);
+    uvm_install2::install(version, modules.as_ref(), install_sync, destination).unwrap_or_else(
+        |err| {
+            error!("Failure during installation");
+            error!("{}", &err);
 
-        for e in err.iter().skip(1) {
-            debug!("{}", &format!("caused by: {}", style(&e).red()));
-        }
+            for e in err.iter().skip(1) {
+                debug!("{}", &format!("caused by: {}", style(&e).red()));
+            }
 
-        if let Some(backtrace) = err.backtrace() {
-            debug!("backtrace: {:?}", backtrace);
-        }
-        process::exit(1);
-    });
+            if let Some(backtrace) = err.backtrace() {
+                debug!("backtrace: {:?}", backtrace);
+            }
+            process::exit(1);
+        },
+    );
 
     eprintln!("{}", style("Finish").green().bold())
 }

--- a/install/uvm-modules/src/main.rs
+++ b/install/uvm-modules/src/main.rs
@@ -3,19 +3,25 @@ use console::Style;
 use itertools::Itertools;
 use std::io;
 use std::ops::Deref;
-use structopt::{clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
+use structopt::{
+    clap::crate_authors, clap::crate_description, clap::crate_version, clap::AppSettings, StructOpt,
+};
 use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
-use uvm_core::unity::{Version, Manifest, Modules, Category};
+use uvm_core::unity::{Category, Manifest, Modules, Version};
+
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
 
 #[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
 struct Opts {
-
     /// filter by category
     #[structopt(long, number_of_values = 1)]
     category: Option<Vec<Category>>,
 
-    /// list also sync modules 
+    /// list also sync modules
     #[structopt(long = "show-sync-modules", short)]
     show_sync_modules: bool,
 
@@ -53,18 +59,18 @@ impl<'a> Deref for Module<'_> {
 }
 
 impl<'a> Module<'a> {
-    pub fn new(module:&'a uvm_core::unity::Module, lookup:&'a [uvm_core::unity::Module]) -> Self {
+    pub fn new(module: &'a uvm_core::unity::Module, lookup: &'a [uvm_core::unity::Module]) -> Self {
         let mut children = Vec::new();
         let base = module;
 
         for m in lookup.iter() {
             match m.sync {
                 Some(id) if id == base.id => children.push(Module::new(m, &lookup)),
-                _ => ()
+                _ => (),
             }
         }
 
-        Module {base, children}
+        Module { base, children }
     }
 
     pub fn children(&self) -> &Vec<Module<'a>> {
@@ -72,19 +78,19 @@ impl<'a> Module<'a> {
     }
 }
 
-pub fn load_modules<V: AsRef<Version>>(version:V) -> Result<Modules> {
+pub fn load_modules<V: AsRef<Version>>(version: V) -> Result<Modules> {
     let version = version.as_ref();
-    let manifest = Manifest::load(version).map_err(|_e| io::Error::new(io::ErrorKind::NotFound, "failed to load manifest"))?;
-    let modules:Modules = manifest.into_modules();
+    let manifest = Manifest::load(version)
+        .map_err(|_e| io::Error::new(io::ErrorKind::NotFound, "failed to load manifest"))?;
+    let modules: Modules = manifest.into_modules();
     Ok(modules)
 }
 
 fn main() -> Result<()> {
-    let opt = Opts::from_args_safe().map(|opt| {
-        set_colors_enabled(&opt.color);
-        set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
-        opt
-    })?;
+    let opt = Opts::from_args();
+
+    set_colors_enabled(&opt.color);
+    set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
 
     list(&opt).context("failed to list Unity modules")?;
     Ok(())
@@ -124,7 +130,15 @@ fn list(options: &Opts) -> Result<()> {
             println!("{}:", category_style.apply_to(module.category.to_string()));
         }
 
-        print_module(&module, "", 0, options.verbose >= 1, &out_style, &path_style, &options);
+        print_module(
+            &module,
+            "",
+            0,
+            options.verbose >= 1,
+            &out_style,
+            &path_style,
+            &options,
+        );
     }
     Ok(())
 }
@@ -136,7 +150,7 @@ fn print_module(
     verbose: bool,
     out_style: &Style,
     path_style: &Style,
-    options: &Opts
+    options: &Opts,
 ) {
     let p_prefix = console::pad_str(prefix, rjust, console::Alignment::Right, None);
     if verbose {
@@ -151,7 +165,11 @@ fn print_module(
     }
 
     if options.show_sync_modules {
-        for sub in module.children().iter().filter(|m| options.all || m.visible) {
+        for sub in module
+            .children()
+            .iter()
+            .filter(|m| options.all || m.visible)
+        {
             print_module(
                 sub,
                 prefix,
@@ -159,7 +177,7 @@ fn print_module(
                 verbose,
                 out_style,
                 path_style,
-                options
+                options,
             );
         }
     }

--- a/install/uvm-versions/src/main.rs
+++ b/install/uvm-versions/src/main.rs
@@ -1,31 +1,38 @@
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashSet;
-use structopt::{clap::crate_authors, clap::crate_description, clap::crate_version, StructOpt};
+use structopt::{
+    clap::crate_authors, clap::crate_description, clap::crate_version, clap::AppSettings, StructOpt,
+};
 use uvm_cli::{options::ColorOption, set_colors_enabled, set_loglevel};
 use uvm_core::unity::VersionType;
 use uvm_versions;
 
+const SETTINGS: &'static [AppSettings] = &[
+    AppSettings::ColoredHelp,
+    AppSettings::DontCollapseArgsInUsage,
+];
+
 #[derive(StructOpt, Debug)]
-#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
+#[structopt(version = crate_version!(), author = crate_authors!(), about = crate_description!(), settings = SETTINGS)]
 struct Opts {
     /// list all available versions for the selected version types
     #[structopt(short, long)]
     all: bool,
 
-    /// list final versions 
+    /// list final versions
     #[structopt(short = "f", long = "final")]
     list_final: bool,
 
-    /// list beta versions 
+    /// list beta versions
     #[structopt(short = "b", long = "beta")]
     list_beta: bool,
 
-    /// list alpha versions 
+    /// list alpha versions
     #[structopt(long = "alpha")]
     list_alpha: bool,
 
-    /// list patch versions 
+    /// list patch versions
     #[structopt(short = "p", long = "patch")]
     list_patch: bool,
 
@@ -47,57 +54,56 @@ struct Opts {
 }
 
 impl uvm_versions::VersionListOptions for Opts {
-  fn list_variants(&self) -> HashSet<VersionType> {
-    let mut variants: HashSet<VersionType> = HashSet::with_capacity(4);
+    fn list_variants(&self) -> HashSet<VersionType> {
+        let mut variants: HashSet<VersionType> = HashSet::with_capacity(4);
 
-    if self.has_variant_flags() {
-        if self.list_alpha {
+        if self.has_variant_flags() {
+            if self.list_alpha {
+                variants.insert(VersionType::Alpha);
+            }
+
+            if self.list_beta {
+                variants.insert(VersionType::Beta);
+            }
+
+            if self.list_patch {
+                variants.insert(VersionType::Patch);
+            }
+
+            if self.list_final {
+                variants.insert(VersionType::Final);
+            }
+        } else {
             variants.insert(VersionType::Alpha);
-        }
-
-        if self.list_beta{
             variants.insert(VersionType::Beta);
-        }
-
-        if self.list_patch {
             variants.insert(VersionType::Patch);
-        }
-
-        if self.list_final {
             variants.insert(VersionType::Final);
         }
-    } else {
-        variants.insert(VersionType::Alpha);
-        variants.insert(VersionType::Beta);
-        variants.insert(VersionType::Patch);
-        variants.insert(VersionType::Final);
+        variants
     }
-    variants
-  }
 
-  fn has_variant_flags(&self) -> bool {
-      self.list_alpha || self.list_beta || self.list_patch || self.list_final
-  }
+    fn has_variant_flags(&self) -> bool {
+        self.list_alpha || self.list_beta || self.list_patch || self.list_final
+    }
 
-  fn filter_versions(&self) -> bool {
-      !self.all
-  }
+    fn filter_versions(&self) -> bool {
+        !self.all
+    }
 
-  fn pattern(&self) -> &Option<Regex> {
-      &self.pattern
-  }
+    fn pattern(&self) -> &Option<Regex> {
+        &self.pattern
+    }
 
-  fn debug(&self) -> bool {
-    self.debug
-  }
+    fn debug(&self) -> bool {
+        self.debug
+    }
 }
 
 fn main() -> Result<()> {
-    let opt = Opts::from_args_safe().map(|opt| {
-        set_colors_enabled(&opt.color);
-        set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
-        opt
-    })?;
+    let opt = Opts::from_args();
+
+    set_colors_enabled(&opt.color);
+    set_loglevel(opt.debug.then(|| 2).unwrap_or(opt.verbose));
 
     uvm_versions::list_versions(&opt).context("failed to list Unity modules")?;
     Ok(())


### PR DESCRIPTION
This patch fixes a small output bug. When calling the help page, the command would
print an error message which comes from the default rust implementation when main returns an error result. This patch simply calls the failing method of `structopt` `from_args` which will panic.

It also enables color output for the cli help.