### PR TITLE
Fix iOSSupport module installation destination on linux

### DIFF
--- a/install/uvm_install_core/src/sys/linux/xz.rs
+++ b/install/uvm_install_core/src/sys/linux/xz.rs
@@ -62,6 +62,22 @@ impl InstallHandler for ModuleXzInstaller {
 
         let destination = self.destination();
         let installer = self.installer();
+        let destination = if destination.ends_with("Editor/Data/PlaybackEngines/iOSSupport") {
+            debug!("adjust install destination for iOSSupport module");
+            destination.parent()
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!(
+                            "Can't determine destination for {} and destination {}",
+                            &installer.display(),
+                            destination.display()
+                        ),
+                    )
+                })?
+        } else {
+            destination
+        };
 
         let destination = if destination.ends_with("Editor/Data/PlaybackEngines") {
             destination


### PR DESCRIPTION
## Description

The `iOSSupport` module is the only package on `macOS` which is archived based on a different base directory than all other packages. This is sadly also true for the linux version of the module. So I adjusted the installation destination when the package destination contains `iOSSupport` in the path.