### PR TITLE
Add option to to list installed modules to umv-list command

### DIFF
--- a/commands/uvm-list/src/main.rs
+++ b/commands/uvm-list/src/main.rs
@@ -40,6 +40,9 @@ struct Opts {
     #[structopt(long)]
     system: bool,
 
+    #[structopt(short = "m", long = "modules")]
+    list_modules: bool,
+
     /// Color:.
     #[structopt(short, long, possible_values = &ColorOption::variants(), case_insensitive = true, default_value)]
     color: ColorOption,
@@ -97,6 +100,11 @@ fn list(options: &Opts) -> io::Result<()> {
                 new_line += &format!("{}", path_style.apply_to(installation.path().display()));
             }
             new_line += "\n";
+            if options.list_modules {
+                for c in installation.installed_components() {
+                    new_line += &format!("  {}\n", out_style.apply_to(c));
+                }
+            }
             new_line
         });
 


### PR DESCRIPTION
## Description

Adds a new commandline option `--modules` or `-m` to print list of installed modules for each installed Unity version.

```
Installed Unity versions:
2020.3.29f1
  standardassets
  example
  android
  ios
  linux
  linux-mono
  linux-il2cpp
  linux-server
2019.4.24f1
  standardassets
  example
  android
  android-sdk-build-tools
  android-sdk-platforms
  android-sdk-platform-tools
  android-sdk-ndk-tools
  android-ndk
  android-open-jdk
  ios
  linux
  linux-mono
  linux-il2cpp
  linux-server
  webgl
```