### PR TITLE
Improve error handling Patch II

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,6 +2639,7 @@ dependencies = [
 name = "uvm_core"
 version = "0.10.0"
 dependencies = [
+ "anyhow",
  "cfg-if 1.0.0",
  "cluFlock",
  "derive_deref",

--- a/uvm_core/Cargo.toml
+++ b/uvm_core/Cargo.toml
@@ -15,6 +15,7 @@ appveyor = { repository = "Larusso/unity-version-manager", branch = "master", se
 maintenance = { status = "experimental" }
 
 [dependencies]
+anyhow = "1.0.38"
 thiserror = "1.0.30"
 cfg-if = "1.0.0"
 lazy_static = "1.3.0"

--- a/uvm_core/src/error.rs
+++ b/uvm_core/src/error.rs
@@ -4,7 +4,6 @@ error_chain! {
     }
 
     links {
-        VersionError(crate::unity::UvmVersionError, crate::unity::UvmVersionErrorKind);
         HubError(crate::unity::hub::UvmHubError, crate::unity::hub::UvmHubErrorKind);
     }
 
@@ -12,6 +11,7 @@ error_chain! {
         Fmt(::std::fmt::Error);
         Io(::std::io::Error);
         NetworkError(reqwest::Error);
+        VersionError(crate::unity::VersionError);
     }
 
     errors {

--- a/uvm_core/src/sys/mac/unity/version/mod.rs
+++ b/uvm_core/src/sys/mac/unity/version/mod.rs
@@ -1,11 +1,8 @@
-use crate::unity::UvmVersionErrorKind;
-use crate::unity::UvmVersionErrorResult as Result;
-use crate::unity::UvmVersionErrorResultExt;
+use crate::unity::VersionError;
 use crate::unity::Version;
 use plist::serde::deserialize;
 use std::convert::AsRef;
 use std::fs::File;
-use std::io;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -18,24 +15,25 @@ pub struct AppInfo {
     pub unity_build_number: String,
 }
 
-pub fn read_version_from_path<P: AsRef<Path>>(path: P) -> Result<Version> {
+pub fn read_version_from_path<P: AsRef<Path>>(path: P) -> Result<Version, VersionError> {
     let path = path.as_ref();
     if !path.exists() {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("Provided Path does not exist. {}", path.display(),),
-        )
-        .into());
+        return Err(VersionError::PathContainsNoVersion(format!(
+            "Provided Path does not exist. {}",
+            path.display()
+        )));
     }
 
     if path.is_dir() {
         //check for the `Unity.app` package
         let info_plist_path = path.join("Unity.app/Contents/Info.plist");
-        let file = File::open(info_plist_path).chain_err(|| "unable to open Info.plist")?;
-        let info: AppInfo = deserialize(file).chain_err(|| "unable to read Info.plist")?;
+        let file = File::open(info_plist_path)?;
+        let info: AppInfo = deserialize(file).map_err(|source| VersionError::Other(source.into()))?;
         let version = Version::from_str(&info.c_f_bundle_version)?;
         return Ok(version);
     }
 
-    Err(UvmVersionErrorKind::NotAUnityInstalltion(path.display().to_string()).into())
+    Err(VersionError::PathContainsNoVersion(
+        path.display().to_string(),
+    ))
 }

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -23,7 +23,7 @@ pub use self::version::module::{Module, Modules, ModulesMap};
 pub use self::version::fetch_matching_version;
 pub use self::version::Version;
 pub use self::version::VersionType;
-pub use self::version::{UvmVersionError, UvmVersionErrorKind, ResultExt as UvmVersionErrorResultExt, Result as UvmVersionErrorResult};
+pub use self::version::{VersionError};
 
 use crate::error::*;
 use itertools::Itertools;

--- a/uvm_core/src/unity/version/error.rs
+++ b/uvm_core/src/unity/version/error.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+use std::io;
+use std::result;
+
+#[derive(Error, Debug)]
+pub enum VersionError {
+    #[error("unable to read version from path. {0}")]
+    PathContainsNoVersion(String),
+
+    #[error("failed to read version from executable {0}")]
+    ExecutableContainsNoVersion(String),
+
+    #[error("failed to parse version '{0}'")]
+    ParsingFailed(String),
+
+    #[error("failed to parse unkown version type {0}")]
+    VersionTypeParsingFailed(String),
+
+    #[error("no version found for match with req {0}")]
+    NoMatch(String),
+
+    #[error("failed to fetch version hash for version {version}")]
+    HashMissing {
+        source: super::hash::UnityHashError,
+        version: String,
+    },
+
+    #[error("failed to read version")]
+    Io {
+        #[from]
+        source: io::Error,
+    },
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+pub type Result<T> = result::Result<T, VersionError>;


### PR DESCRIPTION
## Description

The unity version module already had a custom error implementation based on the `error-chain` cask.
I reimplemented the error based on `thiserror` and cleaned up some cases. I'm not 100% happy about the result but would revisit this again at a later stage. I'm not super fond of the introduction of anyhow as a catch all item.f