### PR TITLE
Improve error handling Patch III

### DIFF
--- a/uvm_core/src/unity/component/category.rs
+++ b/uvm_core/src/unity/component/category.rs
@@ -1,4 +1,4 @@
-use super::error::{ParseComponentError, ParseComponentErrorKind};
+use super::error::ParseComponentError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
@@ -45,7 +45,7 @@ impl FromStr for Category {
             "Components" => Ok(Components),
             "Platforms" => Ok(Platforms),
             "LanguagePack" | "Language packs (Preview)" => Ok(LanguagePack),
-            x => Err(ParseComponentErrorKind::UnsupportedCategory(x.to_string()).into()),
+            x => Err(ParseComponentError::UnsupportedCategory(x.to_string())),
         }
     }
 }

--- a/uvm_core/src/unity/component/error.rs
+++ b/uvm_core/src/unity/component/error.rs
@@ -1,17 +1,15 @@
-error_chain! {
-    types {
-        ParseComponentError, ParseComponentErrorKind, ResultExt, Result;
-    }
+use thiserror::Error;
+use crate::unity::LocalizationError;
 
-    errors {
-        Unsupported(t: String) {
-            description("unsupported component"),
-            display("unsupported component: '{}'", t),
-        }
-
-        UnsupportedCategory(t: String) {
-            description("unsupported component category"),
-            display("unsupported component category: '{}'", t),
-        }
+#[derive(Error, Debug)]
+pub enum ParseComponentError {
+    #[error("unsupported component: {0}")]
+    Unsupported(String),
+    #[error("unsupported component category: {0}")]
+    UnsupportedCategory(String),
+    #[error("unsupported locale")]
+    UnsupportedLocale {
+        #[from]
+        source: LocalizationError,
     }
 }

--- a/uvm_core/src/unity/component/mod.rs
+++ b/uvm_core/src/unity/component/mod.rs
@@ -410,15 +410,21 @@ impl FromStr for Component {
             "lumin" => Ok(Lumin),
             x => {
                 if x.starts_with("language-") {
-                    match x.splitn(2,'-').last().and_then(|sub| Localization::from_str(sub).ok()) {
-                        Some(locale) => Ok(Language(locale)),
-                        None => Err(error::ParseComponentErrorKind::Unsupported(x.to_string()).into())
+                    match x.splitn(2, '-').last() {
+                        Some(locale_name) => Localization::from_str(locale_name).map(|locale| locale.into()).map_err(|err| err.into()),
+                        None => Err(error::ParseComponentError::Unsupported(x.to_string()).into())
                     }
                 } else {
-                    Err(error::ParseComponentErrorKind::Unsupported(x.to_string()).into())
+                    Err(error::ParseComponentError::Unsupported(x.to_string()).into())
                 }
             },
         }
+    }
+}
+
+impl From<Localization> for Component {
+    fn from(locale: Localization) -> Self {
+        Component::Language(locale)
     }
 }
 

--- a/uvm_core/src/unity/localization.rs
+++ b/uvm_core/src/unity/localization.rs
@@ -4,15 +4,13 @@ use std::collections::HashSet;
 use std::str::FromStr;
 
 pub mod error {
-    error_chain! {
-        errors {
-            Unknown(t: String) {
-                description("Unknown localization"),
-                display("Unknown localization: '{}'", t),
-            }
-        }
-    }
+    use thiserror::Error;
 
+    #[derive(Error, Debug)]
+    pub enum Error {
+        #[error("unknown locale {0}")]
+        Unknown(String)
+    }
 }
 
 /// add the localization generic information to the config
@@ -95,7 +93,7 @@ impl FromStr for Localization {
             "zh-hant" => Ok(ZhHant),
             "zh-hans" => Ok(ZhHans),
             "ru" => Ok(Ru),
-            x => Err(error::ErrorKind::Unknown(x.to_string()).into())
+            x => Err(error::Error::Unknown(x.to_string()))
         }
     }
 }

--- a/uvm_core/src/unity/mod.rs
+++ b/uvm_core/src/unity/mod.rs
@@ -13,7 +13,7 @@ pub mod v2 {
 use core::iter::FromIterator;
 pub use self::component::Component;
 pub use self::component::Category;
-pub use self::localization::Localization;
+pub use self::localization::{Localization, error::Error as LocalizationError};
 pub use self::current_installation::current_installation;
 pub use self::current_installation::CurrentInstallation;
 pub use self::installation::Installation;


### PR DESCRIPTION
## Description

Third patch to move from `error_chain` to `thiserror`. In this patch I take care of the `uvm_core::unity::Component` parsing errors for both `Component` and the inner `Localization` enum.