### PR TITLE
Improve error handling Patch IV

### DIFF
--- a/uvm_core/src/error.rs
+++ b/uvm_core/src/error.rs
@@ -3,15 +3,12 @@ error_chain! {
         UvmError, UvmErrorKind, ResultExt, Result;
     }
 
-    links {
-        HubError(crate::unity::hub::UvmHubError, crate::unity::hub::UvmHubErrorKind);
-    }
-
     foreign_links {
         Fmt(::std::fmt::Error);
         Io(::std::io::Error);
         NetworkError(reqwest::Error);
         VersionError(crate::unity::VersionError);
+        HubError(crate::unity::hub::UvmHubError);
     }
 
     errors {

--- a/uvm_core/src/platform.rs
+++ b/uvm_core/src/platform.rs
@@ -40,17 +40,12 @@ impl Default for Platform {
 }
 
 pub mod error {
-    error_chain! {
-        types {
-            ParsePlatformError, ParsePlatformErrorKind, ResultExt, Result;
-        }
+    use thiserror::Error;
 
-        errors {
-            Unsupported(t: String) {
-                description("unsupported platform"),
-                display("unsupported platform: '{}'", t),
-            }
-        }
+    #[derive(Error, Debug)]
+    pub enum ParsePlatformError {
+        #[error("platform not supported: {0}")]
+        NotSupported(String)
     }
 }
 
@@ -62,7 +57,7 @@ impl std::str::FromStr for Platform {
             "osx" => Ok(Platform::MacOs),
             "linux" => Ok(Platform::Linux),
             "win" => Ok(Platform::Win),
-            x => Err(self::error::ParsePlatformErrorKind::Unsupported(x.to_string()).into())
+            x => Err(self::error::ParsePlatformError::NotSupported(x.to_string()))
         }
     }
 }

--- a/uvm_core/src/unity/hub/mod.rs
+++ b/uvm_core/src/unity/hub/mod.rs
@@ -3,42 +3,50 @@ pub mod paths;
 
 use std::io;
 use crate::unity;
+use thiserror::Error;
 //
 
-error_chain! {
-    types {
-        UvmHubError, UvmHubErrorKind, ResultExt, Result;
-    }
+#[derive(Error, Debug)]
+pub enum UvmHubError {
+    #[error("unity hub config: '{0}' is missing")]
+    ConfigNotFound(String),
 
-    foreign_links {
-        Fmt(::std::fmt::Error);
-        Io(::std::io::Error);
-    }
+    #[error("Unity Hub config directory missing")]
+    ConfigDirectoryNotFound,
+   
+    #[error("failed to read Unity Hub config {config}")]
+    ReadConfigError {
+        config: String,
+        source: anyhow::Error,
+    },
 
-    errors {
-        ConfigNotFound(config_name: String) {
-            description("unity hub config missing"),
-            display("unity hub config: '{}' is missing", config_name)
-        }
+    #[error("can't write Unity Hub config: '{config}'")]
+    WriteConfigError {
+        config: String,
+        source: anyhow::Error,
+    },
+    
+    #[error("failed to create config directory")]
+    FailedToCreateConfigDirectory {
+        source: std::io::Error,
+    },
+    
+    #[error("failed to create config file for config {config}")]
+    FailedToCreateConfig {
+        config: String,
+        source: io::Error
+    },
 
-        ConfigDirectoryNotFound {
-            description("unity hub config directory missing")
-        }
-
-        ReadConfigError(config_name: String) {
-            description("error reading unity hub config"),
-            display("error reading unity hub config: '{}'", config_name)
-        }
-        WriteConfigError(config_name: String) {
-            description("error writing unity hub config"),
-            display("error writing unity hub config: '{}'", config_name)
-        }
-    }
+    #[error("Unity Hub editor install path not found")]
+    InstallPathNotFound,
 }
+
+type Result<T> = std::result::Result<T, UvmHubError>;
 
 pub fn list_installations() -> Result<unity::Installations> {
     let install_path = paths::install_path()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "install path not found"))?;
+        .ok_or_else(|| UvmHubError::InstallPathNotFound)?;
+
     debug!("unity hub install path: {}", install_path.display());
 
     let editors = editors::Editors::load()?;


### PR DESCRIPTION
## Description

This patch converts the `UvmHubError` from `error_chain` to `thiserror` backed errors. I already see that I need another general rename patch to clean things up for good after I setup all the different error cases/enums etc.