### PR TITLE
Improve unity version parsing

### DIFF
--- a/uvm_core/src/unity/version/hash.rs
+++ b/uvm_core/src/unity/version/hash.rs
@@ -21,6 +21,9 @@ pub enum UnityHashError {
         #[from]
         source: std::io::Error
     },
+
+    #[error("hash not available")]
+    Other
 }
 
 type Result<T> = std::result::Result<T, UnityHashError>;


### PR DESCRIPTION
## Description

Unity versions always come with two components:
* The actual version string
* a hash part which is mostly invisible

To install and locate the install resources we need both parts. In the past a webservice was used to locate the missing hash by providing a simple mapping. Since Unity 2019 the project settings file declares the project version in two styles:

```
m_EditorVersion: 2020.3.38f1
m_EditorVersionWithRevision: 2020.3.38f1 (8f5fde82e2dc)
```

The newer `m_EditorVersionWithRevision` version already contains the hash/revision (unity itself is not clear how to name this ...) I updated the version `fromString` parser to parse the optional revision when provided. I opted to parse 2 styles. the aformentioned project settings style and also the UnityHub url style `2020.3.38f1/8f5fde82e2dc`.