### PR TITLE
Improve install cache

### DIFF
--- a/install/uvm-install/src/error.rs
+++ b/install/uvm-install/src/error.rs
@@ -8,5 +8,6 @@ error_chain! {
     foreign_links {
         Fmt(::std::fmt::Error);
         Io(::std::io::Error);
+        VersionError(uvm_core::unity::VersionError);
     }
 }

--- a/install/uvm-install/src/lib.rs
+++ b/install/uvm-install/src/lib.rs
@@ -209,12 +209,14 @@ impl UvmCommand {
                 version.to_string()
             ))
             .ok();
+        
+        let version_string = format!("{}-{}", version, version.version_hash()?);
         let locks_dir = paths::locks_dir().ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "Unable to locate locks directory.")
         })?;
 
         fs::DirBuilder::new().recursive(true).create(&locks_dir)?;
-        lock_process!(locks_dir.join(format!("{}.lock", &version)));
+        lock_process!(locks_dir.join(format!("{}.lock", &version_string)));
 
         let mut editor_installation: Option<EditorInstallation> = None;
         let base_dir = if let Some(ref destination) = options.destination() {

--- a/install/uvm-install2/src/error.rs
+++ b/install/uvm-install2/src/error.rs
@@ -8,6 +8,7 @@ error_chain! {
     foreign_links {
         Fmt(::std::fmt::Error);
         Io(::std::io::Error);
+        VersionError(uvm_core::unity::VersionError);
     }
 
     errors {

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -61,12 +61,13 @@ where
     I::Item: AsRef<Component>,
 {
     let version = version.as_ref();
+    let version_string = format!("{}-{}", version, version.version_hash()?);
     let locks_dir = paths::locks_dir().ok_or_else(|| {
         io::Error::new(io::ErrorKind::NotFound, "Unable to locate locks directory.")
     })?;
 
     fs::DirBuilder::new().recursive(true).create(&locks_dir)?;
-    lock_process!(locks_dir.join(format!("{}.lock", version)));
+    lock_process!(locks_dir.join(format!("{}.lock", version_string)));
 
     let mut manifest = Manifest::load(version)?;
     let mut graph = InstallGraph::from(&manifest);

--- a/install/uvm_install_core/src/error.rs
+++ b/install/uvm_install_core/src/error.rs
@@ -6,6 +6,7 @@ error_chain! {
         Io(::std::io::Error);
         NetworkError(::reqwest::Error);
         ZipError(::zip::result::ZipError);
+        VersionError(::uvm_core::unity::VersionError);
     }
 
     errors {

--- a/uvm_core/src/unity/hub/paths.rs
+++ b/uvm_core/src/unity/hub/paths.rs
@@ -44,7 +44,7 @@ pub fn default_editor_config_path() -> Option<PathBuf> {
 }
 
 pub fn cache_dir() -> Option<PathBuf> {
-    dirs_2::cache_dir().map(|path| path.join("Wooga").join("UnityVersionManager"))
+    dirs_2::cache_dir().map(|path| path.join("com.github.larusso.unity-version-manager"))
 }
 
 pub fn locks_dir() -> Option<PathBuf> {

--- a/uvm_core/src/unity/version/manifest/ini.rs
+++ b/uvm_core/src/unity/version/manifest/ini.rs
@@ -95,8 +95,9 @@ impl IniManifest {
                     ),
                 )
             })?;
-
-        let manifest_path = cache_dir.join(&format!("{}_manifest.ini", version.as_ref()));
+        let version = version.as_ref();
+        let version_string = format!("{}-{}", version, version.version_hash()?);
+        let manifest_path = cache_dir.join(&format!("{}_manifest.ini", version_string));
 
         if !manifest_path.exists() {
             Self::download_manifest(version, manifest_path.to_path_buf())
@@ -271,9 +272,10 @@ mod tests {
 
     #[test]
     fn saves_meta_file_to_cache_dir() {
-        let version = Version::f(2019, 1, 7, 1);
+        let mut version = Version::f(2019, 1, 7, 1);
+        version.set_version_hash(Some("f3c4928e5742"));
         let cache_file = paths::cache_dir()
-            .map(|f| f.join(&format!("{}_manifest.ini", version.to_string())))
+            .map(|f| f.join(&format!("{}-{}_manifest.ini", version.to_string(), "f3c4928e5742")))
             .unwrap();
         if cache_file.exists() {
             fs::remove_file(&cache_file).unwrap();

--- a/uvm_core/src/unity/version/mod.rs
+++ b/uvm_core/src/unity/version/mod.rs
@@ -210,8 +210,8 @@ impl Version {
         v
     }
 
-    pub fn set_version_hash(&mut self, hash: Option<String>) {
-        self.hash = hash;
+    pub fn set_version_hash<S: AsRef<str>>(&mut self, hash: Option<S>) {
+        self.hash = hash.map(|s| s.as_ref().to_owned());
     }
 
     pub fn has_version_hash(&self) -> bool {


### PR DESCRIPTION
## Description

The installer cache worked fine and has functionally no issues. The reason I was compelled to patch it is that Unity sometimes creates internal fix releases with a different revision hash. This means that when the actual fix gets rolled out, uvm might think that the installer for the version is already downloaded.
This is a very simple patch to make sure that we use both user version + revision hash as the cache key for the installer and lock files.

While touching it I moved the cache folder to a new home. I use the github domain for the cache dir instead of `Wooga/UnityVersionManager`. I also decided to keep the temp download files in a seperate directory.