### PR TITLE
Remove LinuxMono from list of Unity built-in components

### DIFF
--- a/uvm_core/src/sys/linux/unity/component.rs
+++ b/uvm_core/src/sys/linux/unity/component.rs
@@ -5,7 +5,7 @@ pub fn installpath(component:Component) -> Option<PathBuf> {
     use Component::*;
     let path = match component {
         Mono | VisualStudio | MonoDevelop => None,
-        LinuxMono | StandardAssets | Example => Some(""),
+        StandardAssets | Example => Some(""),
         Documentation => Some("Editor/Data/Documentation"),
         ExampleProject  => None,
         Android => Some("Editor/Data/PlaybackEngines/AndroidPlayer"),


### PR DESCRIPTION
## Description

The `LinuxMono` unity component is listed as one of the default 'built-in' linux components. While unity work as the linux-mono component is already installed, this generates an inconsistency with other OSes that doesn't list their [os]-mono packages, which behave in the same way. 
This PR removes the LinuxMono from the list built-in linux components to keep consistency. 