### PR TITLE
Add new crate to connect to unity live platform service

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,1 @@
+{ "schemaPath": "uvm_live_platform/schema.graphql" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +60,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.55"
+name = "anstream"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "argon2rs"
@@ -75,7 +138,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi 0.3.9",
 ]
@@ -140,6 +203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +228,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "blake2-rfc"
@@ -192,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +294,12 @@ dependencies = [
  "either",
  "iovec",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bzip2"
@@ -237,9 +324,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -255,15 +345,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
  "time",
- "winapi 0.3.9",
+ "wasm-bindgen",
+ "windows-targets 0.48.3",
 ]
 
 [[package]]
@@ -274,12 +366,52 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
- "strsim",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clicolors-control"
@@ -311,7 +443,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -323,6 +455,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
@@ -359,17 +497,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
+ "lazy_static 1.4.0",
  "libc",
- "once_cell",
- "regex 1.5.6",
- "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -397,7 +533,7 @@ dependencies = [
  "cookie",
  "failure",
  "idna 0.1.5",
- "log 0.4.14",
+ "log 0.4.20",
  "publicsuffix",
  "serde",
  "serde_json",
@@ -432,14 +568,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.15",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
@@ -450,10 +607,23 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static 1.4.0",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg 1.1.0",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -464,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -477,6 +647,15 @@ dependencies = [
  "autocfg 1.1.0",
  "cfg-if 0.1.10",
  "lazy_static 1.4.0",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -496,7 +675,7 @@ checksum = "dcdbcee2d9941369faba772587a565f4f534e42cb8d17e5295871de730163b2b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -564,9 +743,36 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime 2.1.0",
- "log 0.4.14",
+ "log 0.4.20",
  "regex 1.5.6",
  "termcolor",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -597,7 +803,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.86",
  "synstructure",
 ]
 
@@ -638,7 +844,7 @@ dependencies = [
  "chrono",
  "glob",
  "lazy_static 1.4.0",
- "log 0.4.14",
+ "log 0.4.20",
  "regex 1.5.6",
  "thiserror",
  "yansi",
@@ -654,10 +860,26 @@ dependencies = [
  "chrono",
  "glob",
  "lazy_static 1.4.0",
- "log 0.4.14",
+ "log 0.4.20",
  "regex 1.5.6",
  "thiserror",
  "yansi",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bce3f7c47b1db54c6f069388db50c82c0cf12268759a360c15d21b81f5e6123"
+dependencies = [
+ "chrono",
+ "glob",
+ "is-terminal",
+ "lazy_static 1.4.0",
+ "log 0.4.20",
+ "nu-ansi-term",
+ "regex 1.5.6",
+ "thiserror",
 ]
 
 [[package]]
@@ -703,7 +925,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fuchsia-zircon-sys",
 ]
 
@@ -720,6 +942,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +964,39 @@ checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
  "futures",
  "num_cpus",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -768,15 +1038,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "fnv",
  "futures",
- "http",
- "indexmap",
- "log 0.4.14",
+ "http 0.1.21",
+ "indexmap 1.8.0",
+ "log 0.4.20",
  "slab",
  "string",
  "tokio-io",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+dependencies = [
+ "bytes 1.4.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.9",
+ "indexmap 1.8.0",
+ "slab",
+ "tokio 1.32.0",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -784,6 +1073,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -795,6 +1090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +1103,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -831,9 +1138,20 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "fnv",
  "itoa 0.4.8",
+]
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes 1.4.0",
+ "fnv",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -842,17 +1160,34 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
- "http",
+ "http 0.1.21",
  "tokio-buf",
 ]
 
 [[package]]
-name = "httparse"
-version = "1.6.0"
+name = "http-body"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes 1.4.0",
+ "http 0.2.9",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -875,20 +1210,20 @@ version = "0.12.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c843caf6296fc1f93444735205af9ed4e109a539005abb2564ae1d6fad34c52"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "futures-cpupool",
- "h2",
- "http",
- "http-body",
+ "h2 0.1.26",
+ "http 0.1.21",
+ "http-body 0.1.0",
  "httparse",
  "iovec",
  "itoa 0.4.8",
- "log 0.4.14",
+ "log 0.4.20",
  "net2",
  "rustc_version",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
  "tokio-io",
@@ -896,7 +1231,31 @@ dependencies = [
  "tokio-tcp",
  "tokio-threadpool",
  "tokio-timer",
- "want",
+ "want 0.2.0",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes 1.4.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.20",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.1",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio 1.32.0",
+ "tower-service",
+ "tracing",
+ "want 0.3.1",
 ]
 
 [[package]]
@@ -905,11 +1264,47 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
- "hyper",
+ "hyper 0.12.36",
  "native-tls",
  "tokio-io",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.4.0",
+ "hyper 0.14.27",
+ "native-tls",
+ "tokio 1.32.0",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -941,7 +1336,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -950,7 +1355,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
 dependencies = [
- "console 0.15.0",
+ "console 0.15.7",
  "lazy_static 0.2.11",
  "parking_lot 0.12.0",
  "regex 0.2.11",
@@ -962,7 +1367,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.15.0",
+ "console 0.15.7",
  "lazy_static 1.4.0",
  "number_prefix",
  "regex 1.5.6",
@@ -973,6 +1378,12 @@ name = "indoc"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
+name = "indoc"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "instant"
@@ -990,6 +1401,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1023,6 +1451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,15 +1483,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -1080,17 +1523,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.20",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "matches"
@@ -1126,6 +1566,15 @@ name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -1168,11 +1617,22 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.14",
+ "log 0.4.20",
  "miow",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1189,13 +1649,13 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.14",
+ "log 0.4.20",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1223,13 +1683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
+name = "nu-ansi-term"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
- "autocfg 1.1.0",
- "num-traits",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1247,7 +1706,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1268,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -1284,7 +1743,7 @@ version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -1357,7 +1816,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.10",
  "smallvec 1.8.0",
- "windows-sys",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -1380,6 +1839,18 @@ checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 dependencies = [
  "fixedbitset",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1427,7 +1898,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.86",
  "version_check",
 ]
 
@@ -1444,11 +1915,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1458,7 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static 1.4.0",
  "num-traits",
@@ -1489,9 +1960,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1657,6 +2128,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque 0.8.3",
+ "crossbeam-utils 0.8.16",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,7 +2170,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1747,31 +2240,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
  "base64 0.10.1",
- "bytes",
+ "bytes 0.4.12",
  "cookie",
  "cookie_store",
  "encoding_rs",
  "flate2",
  "futures",
- "http",
- "hyper",
- "hyper-tls",
- "log 0.4.14",
+ "http 0.1.21",
+ "hyper 0.12.36",
+ "hyper-tls 0.3.2",
+ "log 0.4.20",
  "mime",
  "mime_guess",
  "native-tls",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.5.5",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
  "tokio-threadpool",
  "tokio-timer",
  "url 1.7.2",
  "uuid",
- "winreg",
+ "winreg 0.6.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64 0.21.2",
+ "bytes 1.4.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.20",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log 0.4.20",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding 2.1.0",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.1",
+ "tokio 1.32.0",
+ "tokio-native-tls",
+ "tower-service",
+ "url 2.2.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -1793,6 +2323,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1853,7 +2396,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1893,22 +2436,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1924,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1946,15 +2489,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "indexmap",
+ "indexmap 1.8.0",
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1979,12 +2547,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
 ]
 
 [[package]]
@@ -2000,12 +2588,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static 1.4.0",
  "structopt-derive",
 ]
@@ -2016,11 +2610,11 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -2035,6 +2629,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,7 +2647,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.86",
  "unicode-xid",
 ]
 
@@ -2070,16 +2675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "termios"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,7 +2691,7 @@ checksum = "877189d680101869f65ef94168105d6c188b3a143c13a2d42cf8a09c4c704f8a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -2110,22 +2705,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2169,9 +2764,9 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-current-thread",
  "tokio-executor",
@@ -2183,12 +2778,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+dependencies = [
+ "backtrace",
+ "bytes 1.4.0",
+ "libc",
+ "mio 0.8.8",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2 0.5.3",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "tokio-buf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "either",
  "futures",
 ]
@@ -2209,7 +2820,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures",
 ]
 
@@ -2219,9 +2830,19 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
- "log 0.4.14",
+ "log 0.4.20",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio 1.32.0",
 ]
 
 [[package]]
@@ -2230,11 +2851,11 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures",
  "lazy_static 1.4.0",
- "log 0.4.14",
- "mio",
+ "log 0.4.20",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
  "slab",
@@ -2259,10 +2880,10 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -2273,12 +2894,12 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
- "crossbeam-deque",
+ "crossbeam-deque 0.7.4",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures",
  "lazy_static 1.4.0",
- "log 0.4.14",
+ "log 0.4.20",
  "num_cpus",
  "slab",
  "tokio-executor",
@@ -2290,17 +2911,57 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures",
  "slab",
  "tokio-executor",
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.3"
+name = "tokio-util"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes 1.4.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio 1.32.0",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "try_from"
@@ -2309,6 +2970,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2339,6 +3020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +3051,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "url"
@@ -2393,6 +3086,12 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -2442,8 +3141,8 @@ dependencies = [
  "anyhow",
  "console 0.9.2",
  "flexi_logger 0.16.3",
- "log 0.4.14",
- "reqwest",
+ "log 0.4.20",
+ "reqwest 0.9.24",
  "serde",
  "serde_derive",
  "structopt",
@@ -2461,7 +3160,7 @@ dependencies = [
  "flexi_logger 0.16.3",
  "indicatif 0.15.0",
  "lazy_static 1.4.0",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "stringreader",
@@ -2480,7 +3179,7 @@ dependencies = [
  "flexi_logger 0.16.3",
  "indicatif 0.15.0",
  "lazy_static 1.4.0",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2488,6 +3187,21 @@ dependencies = [
  "structopt",
  "uvm_cli",
  "uvm_core",
+]
+
+[[package]]
+name = "uvm-generate-versions-yaml"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.4.2",
+ "console 0.15.7",
+ "flexi_logger 0.26.0",
+ "log 0.4.20",
+ "rayon",
+ "serde_yaml 0.9.25",
+ "uvm_core",
+ "uvm_live_platform",
 ]
 
 [[package]]
@@ -2510,7 +3224,7 @@ dependencies = [
  "error-chain",
  "flexi_logger 0.16.3",
  "indicatif 0.15.0",
- "log 0.4.14",
+ "log 0.4.20",
  "structopt",
  "uvm_cli",
  "uvm_core",
@@ -2526,7 +3240,7 @@ dependencies = [
  "env_logger",
  "error-chain",
  "indicatif 0.15.0",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "structopt",
@@ -2544,7 +3258,7 @@ version = "2.4.0"
 dependencies = [
  "anyhow",
  "console 0.9.2",
- "log 0.4.14",
+ "log 0.4.20",
  "structopt",
  "uvm_cli",
  "uvm_core",
@@ -2556,7 +3270,7 @@ version = "2.5.0"
 dependencies = [
  "anyhow",
  "console 0.9.2",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "structopt",
@@ -2573,7 +3287,7 @@ dependencies = [
  "flexi_logger 0.16.3",
  "indicatif 0.15.0",
  "itertools 0.9.0",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "structopt",
@@ -2587,7 +3301,7 @@ version = "2.5.0"
 dependencies = [
  "anyhow",
  "console 0.9.2",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "structopt",
@@ -2603,7 +3317,7 @@ dependencies = [
  "anyhow",
  "console 0.6.2",
  "indicatif 0.9.0",
- "log 0.4.14",
+ "log 0.4.20",
  "semver 1.0.6",
  "structopt",
  "uvm_cli",
@@ -2618,7 +3332,7 @@ dependencies = [
  "console 0.9.2",
  "indicatif 0.15.0",
  "itertools 0.9.0",
- "log 0.4.14",
+ "log 0.4.20",
  "regex 1.5.6",
  "serde",
  "serde_derive",
@@ -2634,7 +3348,7 @@ dependencies = [
  "console 0.9.2",
  "flexi_logger 0.17.1",
  "itertools 0.10.3",
- "log 0.4.14",
+ "log 0.4.20",
  "serde",
  "serde_derive",
  "structopt",
@@ -2653,23 +3367,23 @@ dependencies = [
  "error-chain",
  "hex 0.4.3",
  "hex-serde",
- "indoc",
+ "indoc 1.0.7",
  "itertools 0.9.0",
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.14",
+ "log 0.4.20",
  "md-5",
  "plist 0.3.0",
  "proptest",
  "rand 0.7.3",
  "regex 1.5.6",
- "reqwest",
+ "reqwest 0.9.24",
  "semver 1.0.6",
  "serde",
  "serde_derive",
  "serde_ini",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.23",
  "stringreader",
  "tempfile",
  "thiserror",
@@ -2688,9 +3402,9 @@ dependencies = [
  "error-chain",
  "hex 0.4.3",
  "hex-serde",
- "log 0.4.14",
+ "log 0.4.20",
  "md-5",
- "reqwest",
+ "reqwest 0.9.24",
  "tempfile",
  "uvm_core",
  "uvm_move_dir",
@@ -2710,10 +3424,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "uvm_live_platform"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "indoc 2.0.3",
+ "reqwest 0.11.18",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "typed-builder",
+]
+
+[[package]]
 name = "uvm_move_dir"
 version = "0.1.1"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.20",
  "tempfile",
  "widestring",
  "winapi 0.3.9",
@@ -2759,7 +3486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures",
- "log 0.4.14",
+ "log 0.4.20",
+ "try-lock",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
  "try-lock",
 ]
 
@@ -2774,6 +3510,88 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log 0.4.20",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "widestring"
@@ -2825,17 +3643,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.3",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f51fb4c64f8b770a823c043c7fad036323e1c48f55287b7bbb7987b2fcdf3b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.3",
+ "windows_aarch64_msvc 0.48.3",
+ "windows_i686_gnu 0.48.3",
+ "windows_i686_msvc 0.48.3",
+ "windows_x86_64_gnu 0.48.3",
+ "windows_x86_64_gnullvm 0.48.3",
+ "windows_x86_64_msvc 0.48.3",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde1bb55ae4ce76a597a8566d82c57432bc69c039449d61572a7a353da28f68c"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2844,10 +3731,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1513e8d48365a78adad7322fd6b5e4c4e99d92a69db8df2d435b25b1f1f286d4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60587c0265d2b842298f5858e1a5d79d146f9ee0c37be5782e92a6eb5e1d7a83"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2856,10 +3767,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224fe0e0ffff5d2ea6a29f82026c8f43870038a0ffc247aa95a52b47df381ac4"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fc52a0f50a088de499712cbc012df7ebd94e2d6eb948435449d76a6287e7ad"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2093925509d91ea3d69bcd20238f4c2ecdb1a29d3c281d026a09705d0dd35f3d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2868,10 +3815,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
+
+[[package]]
 name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -2892,7 +3860,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "uvm_core",
   "uvm_cli",
   "uvm_install_graph",
+  "uvm_live_platform",
   "uvm_move_dir",
   "commands/*",
   "install/*"

--- a/commands/uvm-generate-versions-yaml/Cargo.toml
+++ b/commands/uvm-generate-versions-yaml/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uvm-generate-versions-yaml"
+version = "0.1.0"
+authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
+description = "Generate the versions.yml file for versions service"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.4.2", features = ["derive", "env"] }
+console = "0.15.7"
+flexi_logger = "0.26.0"
+log = "0.4.20"
+rayon = "1.7.0"
+serde_yaml = "0.9.25"
+uvm_live_platform = {path = "../../uvm_live_platform"}
+uvm_core = {path = "../../uvm_core"}

--- a/commands/uvm-generate-versions-yaml/src/cli.rs
+++ b/commands/uvm-generate-versions-yaml/src/cli.rs
@@ -1,0 +1,75 @@
+use clap::{ValueEnum, Parser, ArgAction};
+use console::Style;
+use flexi_logger::{DeferredNow, LogSpecification, Logger};
+use log::{Record, Level, LevelFilter};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+#[clap(propagate_version = true)]
+pub struct Cli {
+    /// print more output
+    #[clap(short, long, action = ArgAction::Count)]
+    pub verbose: u8,
+
+    /// print debug output
+    #[clap(short, long)]
+    pub debug: bool,
+
+    /// Color:.
+    #[clap(short, long, value_enum, env = "COLOR_OPTION", default_missing_value("always"), num_args(0..=1), default_value_t = ColorOption::default())]
+    pub color: ColorOption,
+}
+
+pub fn set_colors_enabled(color: &ColorOption) {
+    use ColorOption::*;
+    match color {
+        Never => console::set_colors_enabled(false),
+        Always => console::set_colors_enabled(true),
+        Auto => (),
+    };
+}
+
+pub fn set_loglevel(verbose: i32) {
+    let mut log_sepc_builder = LogSpecification::builder();
+    let level = match verbose {
+        0 => LevelFilter::Warn,
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Debug,
+        _ => LevelFilter::max(),
+    };
+
+    log_sepc_builder.default(level);
+    let log_spec = log_sepc_builder.build();
+    Logger::with(log_spec).format(format_logs).start().unwrap();
+}
+
+pub fn format_logs(
+    write: &mut dyn std::io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    let style = match record.level() {
+        Level::Trace => Style::new().white().dim().italic(),
+        Level::Debug => Style::new().white().dim(),
+        Level::Info => Style::new().green(),
+        Level::Warn => Style::new().yellow(),
+        Level::Error => Style::new().red(),
+    };
+
+    write
+        .write(&format!("{}", style.apply_to(record.args())).into_bytes())
+        .map(|_| ())
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum ColorOption {
+    Auto,
+    Always,
+    Never,
+}
+
+impl Default for ColorOption {
+    fn default() -> Self {
+        Self::Auto
+    }
+}

--- a/commands/uvm-generate-versions-yaml/src/main.rs
+++ b/commands/uvm-generate-versions-yaml/src/main.rs
@@ -1,0 +1,58 @@
+use std::{collections::{HashMap, BTreeMap}, str::FromStr};
+
+use clap::Parser;
+use cli::*;
+use log::*;
+use rayon::prelude::*;
+use uvm_core::Version;
+use uvm_live_platform::{ListVersions, UnityReleaseDownloadArchitecture, UnityReleaseStream};
+
+mod cli;
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let args = Cli::parse();
+    set_colors_enabled(&args.color);
+    set_loglevel(args.debug.then(|| 2).unwrap_or(i32::from(args.verbose)));
+
+    print!("{:?}", args);
+    let streams = vec![
+        UnityReleaseStream::Alpha,
+        UnityReleaseStream::Beta,
+        UnityReleaseStream::Lts,
+        UnityReleaseStream::Tech,
+    ];
+
+    let versions = streams
+        .par_iter()
+        .map(|stream| {
+            ListVersions::builder()
+                .architecture(UnityReleaseDownloadArchitecture::X86_64)
+                .autopage(true)
+                .include_revision(true)
+                .stream(stream.to_owned())
+                .list()
+        })
+        .filter_map(|v| v.ok())
+        .fold(
+            || {
+                let v: Vec<String> = vec![];
+                v
+            },
+            |mut a, b| {
+                let mut b_vec: Vec<String> = b.collect();
+                a.append(&mut b_vec);
+                a
+            },
+        )
+        .flatten_iter()
+        .filter_map(|v| Version::from_str(&v).ok())
+        .map(|v| {
+            let hash = v.version_hash().expect("expect revision hash to be included").to_owned();
+            (v, hash)
+        })
+        .collect::<BTreeMap<Version, String>>();
+
+    let s = serde_yaml::to_string(&versions)?;
+    print!("{}", s);
+    Ok(())
+}

--- a/uvm_live_platform/Cargo.toml
+++ b/uvm_live_platform/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uvm_live_platform"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.75"
+indoc = "2.0.3"
+reqwest = { version = "0.11.18", features = ["serde_json", "blocking", "json"] }
+serde = { version = "1.0.183", features = ["derive"] }
+serde_json = "1.0.105"
+thiserror = "1.0.47"
+typed-builder = "0.15.2"

--- a/uvm_live_platform/schema.graphql
+++ b/uvm_live_platform/schema.graphql
@@ -1,0 +1,2197 @@
+"""Exposes a URL that specifies the behavior of this scalar."""
+directive @specifiedBy(
+  """The URL that specifies the behavior of this scalar."""
+  url: String!
+) on SCALAR
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @auth on OBJECT | FIELD_DEFINITION
+
+scalar _Any
+
+scalar _FieldSet
+
+"""
+Boundary values related to a Product Variant of type `UnitVariant` within which the price is applicable.
+"""
+type Boundary {
+  """The start value of the Product Variant."""
+  start: Float!
+
+  """The end value of the Product Variant."""
+  end: Float!
+}
+
+"""A Unity Hub Community Resource."""
+type CommunityResource {
+  """The localized human-readable title of the Community Resource."""
+  title: String!
+
+  """The localized description of the Community Resource."""
+  description: String!
+
+  """The localized URL of the Community Resource."""
+  url: URL!
+
+  """The localized thumbnail of the Community Resource."""
+  thumbnail: ResourceMedia!
+}
+
+"""Possible values of Community Resource Order."""
+enum CommunityResourceOrder {
+  WEIGHTED_DESC
+}
+
+"""
+A Composite Metered Product is one which contains a subset of Metered Products
+(for example, Unity Simulation). The price points are all on the child products.
+It extends the `ProductInterface` by adding a list of `products` as it's Metered
+Product children.
+"""
+type CompositeMeteredProduct implements ProductInterface {
+  """The slug of the Product."""
+  slug: ID!
+
+  """The SKU of the Product."""
+  sku: ID!
+
+  """The name of the Product."""
+  name: String!
+
+  """The type of the Product."""
+  type: ProductType!
+
+  """The description of the Product."""
+  description: String!
+
+  """The UI Page of the Product."""
+  ui: UIPage!
+
+  """The child products of the Composite Metered Product."""
+  products: [MeteredProduct!]!
+}
+
+"""Input fields to create a new Organization."""
+input CreateOrganizationInput {
+  """The name of the Organization."""
+  name: String!
+}
+
+"""The response of a Create Organization Mutation."""
+union CreateOrganizationResponse = CreateOrganizationResult | ServerError
+
+"""The result of a Create Organization Mutation."""
+type CreateOrganizationResult {
+  """The indication whether the Organization has been successfully created."""
+  success: Boolean!
+
+  """The organization that has been created."""
+  organization: Organization!
+}
+
+"""Possible types of Currency."""
+enum Currency {
+  BRL
+  CNY
+  EUR
+  JPY
+  KRW
+  USD
+}
+
+"""
+A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the
+`date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO
+8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar DateTime
+
+"""
+A field whose value conforms to the standard internet email address format as
+specified in HTML Spec:
+https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
+"""
+scalar EmailAddress
+
+"""
+An Error is returned when any form of operational error is thrown by the Live Platform.
+"""
+interface Error {
+  """The title of the Error."""
+  title: String!
+
+  """The message of the Error."""
+  message: String!
+
+  """The errorCode of the Error."""
+  errorCode: String!
+}
+
+"""An Extra Field."""
+type ExtraField {
+  """The name of the Extra Field."""
+  name: String!
+
+  """The value of the Extra Field."""
+  value: String!
+}
+
+"""Possible types of FileType."""
+enum FileType {
+  TEXT
+  TAR_GZ
+  TAR_XZ
+  ZIP
+  PKG
+  EXE
+  PO
+  DMG
+  LZMA
+  LZ4
+  MD
+  PDF
+}
+
+"""A Flat pricing for Product."""
+type FlatVariant {
+  """The id of the Flat Variant."""
+  id: ID!
+
+  """The name of the Flat Variant."""
+  name: String!
+
+  """The price of the Flat Variant."""
+  price: Price!
+}
+
+"""A Unity Hub Content."""
+type HubContent {
+  """The unique identifier of the Hub Content."""
+  id: ID!
+
+  """The localized title of the Hub Content."""
+  title: String!
+
+  """The localized description of the Hub Content."""
+  description: String!
+
+  """The localized call-to-action of the Hub Content."""
+  cta: String!
+
+  """The localized link for the call-to-action of the Hub Content."""
+  link: URL!
+
+  """The thumbnail of the Hub Content."""
+  thumbnail: ResourceMedia!
+}
+
+"""A Unity Hub Content Category."""
+type HubContentCategory {
+  """The unique identifier of the Hub Content Category."""
+  id: ID!
+
+  """The unique human readable identifier of the Hub Content Category."""
+  slug: String!
+
+  """The localized name of the Hub Content Category."""
+  name: String!
+
+  """The localized title of the Hub Content Category."""
+  title: String!
+
+  """The localized description of the Hub Content Category."""
+  description: String!
+
+  """
+  The icon of the Hub Content Category, this is an internal Hub Icon Reference.
+  """
+  icon: String!
+
+  """The localized contents of the Hub Content Category."""
+  hubContent(
+    """The sorting arguments for a HubContentCategory query."""
+    orderBy: HubContentOrder = WEIGHTED_DESC
+  ): [HubContent!]!
+}
+
+"""The sorting order for Hub Content Categories."""
+enum HubContentCategoryOrder {
+  WEIGHTED_DESC
+  WEIGHTED_ASC
+}
+
+"""The sorting order for Hub Contents."""
+enum HubContentOrder {
+  WEIGHTED_DESC
+  WEIGHTED_ASC
+}
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
+
+"""A Learn Course."""
+type LearnCourse implements LearnEntityInterface {
+  """The ID of the Learn Entity."""
+  id: ID!
+
+  """The type of the Learn Entity."""
+  type: LearnEntityType!
+
+  """The title of the Learn Entity."""
+  title: String!
+
+  """The description of the Learn Entity."""
+  description: String!
+
+  """The proprietary Draft JS JSON description of the Learn Entity."""
+  draftJSDescription: String!
+
+  """
+  The thumbnail of the Learn Entity. A fallback image is returned if no thumbnail is available.
+  """
+  thumbnail: LearnMedia!
+
+  """The language of the Learn Entity."""
+  language: LearnEntityLanguage!
+
+  """The duration in minutes of the Learn Entity."""
+  duration: LearnTimeValue!
+
+  """The total number of bookmarks of the Learn Entity."""
+  totalBookmarks: Int!
+
+  """The web URL of the Learn Entity."""
+  url: URL!
+
+  """The skill level of the Learn Entity."""
+  skillLevel: LearnEntitySkillLevel!
+
+  """The author of the Learn Entity."""
+  author: LearnEntityAuthor!
+
+  """The list of topics related to the Learn Entity."""
+  topics: [LearnEntityTopic!]!
+
+  """The list of industries related to the Learn Entity."""
+  industries: [LearnEntityIndustry!]!
+
+  """The supported Unity editor version of the Learn Entity."""
+  supportedEditorVersion: String!
+
+  """The list of learning materials related to the Learn Entity."""
+  materials: [LearnEntityMaterial!]
+
+  """The Unity Connect group of the Learn Entity."""
+  connectGroup: LearnEntityConnectGroup
+
+  """The list of contents related to the Learn Course."""
+  contents: [LearnEntityInterface!]
+}
+
+"""Possible types of Learn Digital Unit."""
+enum LearnDigitalUnit {
+  BYTE
+  KILOBYTE
+  MEGABYTE
+  GIGABYTE
+}
+
+"""A Digital Value as defined on Learn Live Platform."""
+type LearnDigitalValue {
+  """The value of the Digital Value."""
+  value: Float!
+
+  """The unit of the Digital Value."""
+  unit: LearnDigitalUnit!
+}
+
+"""A Learn Entity Author."""
+type LearnEntityAuthor {
+  """The ID generated from Connect API of the Learn Entity Author."""
+  id: ID!
+
+  """The name of the Learn Entity Author."""
+  name: String!
+
+  """
+  The avatar of the Learn Entity Author. A fallback image is returned if no author avatar is available.
+  """
+  avatar: LearnMedia!
+}
+
+"""Input fields to add/remove a bookmark to/from a Learn Entity."""
+input LearnEntityBookmarkMutationInput {
+  """The ID of the Learn Entity."""
+  id: ID!
+
+  """The type of the Learn Entity."""
+  type: LearnEntityType!
+}
+
+"""A Learn Entity Bookmark Response."""
+union LearnEntityBookmarkMutationResponse = LearnEntityBookmarkResult | NotFoundError | ServerError
+
+"""Response for a `addLearnEntityBookmark` mutation."""
+type LearnEntityBookmarkResult {
+  """
+  The indication whether the bookmark has been successfully added to the Learn Entity or not.
+  """
+  success: Boolean!
+}
+
+"""A Unity Connect group related to a Learn Entity."""
+type LearnEntityConnectGroup {
+  """The name of the Unity Connect group for the Learn Entity."""
+  name: String!
+
+  """The Unity Connect group's URL for the Learn Entity."""
+  url: URL!
+
+  """
+  The statistics about members of the Unity Connect group for the Learn Entity.
+  """
+  members: LearnEntityConnectGroupMembersStatistics!
+}
+
+"""A Learn Entity Connect Group Members Statistics."""
+type LearnEntityConnectGroupMembersStatistics {
+  """The total members of the Unity Connect group for the Learn Entity."""
+  total: Int!
+
+  """
+  The number of online members of the Unity Connect group for the Learn Entity.
+  """
+  online: Int!
+}
+
+"""A Learn Entity Documentation Link."""
+type LearnEntityDocumentationLink {
+  """The URL of the Learn Entity Documentation Link."""
+  url: URL!
+
+  """The name of the Learn Entity Documentation Link."""
+  name: String!
+}
+
+"""A Learn Entity Downloadable Asset."""
+type LearnEntityDownloadableAsset {
+  """The URL of the Learn Entity Downloadable Asset."""
+  url: URL!
+
+  """The file size of the Learn Entity Downloadable Asset."""
+  size(
+    """The format of the Learn Digital Value size."""
+    format: LearnDigitalUnit! = BYTE
+  ): LearnDigitalValue!
+
+  """The name of the Learn Entity Downloadable Asset."""
+  name: String!
+
+  """The supported editor version of the Learn Entity Downloadable Asset."""
+  supportedEditorVersion: String!
+
+  """The packageId from Asset Store of the Learn Entity Downloadable Asset."""
+  packageId: String!
+}
+
+"""Possible duration filters of searchCatalog Query."""
+enum LearnEntityDuration {
+  LESS_THAN_15_MINUTES
+  BETWEEN_15_AND_60_MINUTES
+  BETWEEN_60_AND_120_MINUTES
+  MORE_THAN_120_MINUTES
+}
+
+"""Possible industry values of a Learn Entity Industry."""
+enum LearnEntityIndustry {
+  AEC
+  AUTOMOTIVE
+  FILM
+  GAMES
+}
+
+"""A Learn Entity Interface returned from the learn queries."""
+interface LearnEntityInterface {
+  """The ID of the Learn Entity."""
+  id: ID!
+
+  """The type of the Learn Entity."""
+  type: LearnEntityType!
+
+  """The title of the Learn Entity."""
+  title: String!
+
+  """The description of the Learn Entity."""
+  description: String!
+
+  """The proprietary Draft JS JSON description of the Learn Entity."""
+  draftJSDescription: String!
+
+  """
+  The thumbnail of the Learn Entity. A fallback image is returned if no thumbnail is available.
+  """
+  thumbnail: LearnMedia!
+
+  """The language of the Learn Entity."""
+  language: LearnEntityLanguage!
+
+  """The duration in minutes of the Learn Entity."""
+  duration: LearnTimeValue!
+
+  """The total number of bookmarks of the Learn Entity."""
+  totalBookmarks: Int!
+
+  """The web URL of the Learn Entity."""
+  url: URL!
+
+  """The skill level of the Learn Entity."""
+  skillLevel: LearnEntitySkillLevel!
+
+  """The author of the Learn Entity."""
+  author: LearnEntityAuthor!
+
+  """The list of topics related to the Learn Entity."""
+  topics: [LearnEntityTopic!]!
+
+  """The list of industries related to the Learn Entity."""
+  industries: [LearnEntityIndustry!]!
+
+  """The supported Unity editor version of the Learn Entity."""
+  supportedEditorVersion: String!
+
+  """The list of learning materials related to the Learn Entity."""
+  materials: [LearnEntityMaterial!]
+
+  """The Unity Connect group of the Learn Entity."""
+  connectGroup: LearnEntityConnectGroup
+}
+
+"""Possible language values of a Learn Entity Language."""
+enum LearnEntityLanguage {
+  ENGLISH
+  CHINESE
+  JAPANESE
+  KOREAN
+  RUSSIAN
+  SPANISH
+  FRENCH
+  GERMAN
+  PORTUGUESE
+}
+
+"""
+Types that can represent a Learn Entity Material in the Learn Entity materials.
+"""
+union LearnEntityMaterial = LearnEntityDownloadableAsset | LearnEntityDocumentationLink
+
+"""A relay style offset paginated Learn Entity Connection."""
+type LearnEntityOffsetConnection {
+  """The list of offset paginated Learn Entity edges."""
+  edges: [LearnEntityOffsetEdge!]!
+
+  """The total count of all available Learn Entity edges in the connection."""
+  totalCount: Int!
+
+  """The page information for offset pagination."""
+  pageInfo: LearnEntityOffsetPageInfo!
+}
+
+"""A relay style offset paginated Learn Entity Edge."""
+type LearnEntityOffsetEdge {
+  """A Learn Entity node."""
+  node: LearnEntityResponse!
+}
+
+"""The LearnEntity Offset Pagination Information related to a connection."""
+type LearnEntityOffsetPageInfo {
+  """The flag indicating if there is a next results page."""
+  hasNextPage: Boolean!
+
+  """The flag indicating if there is a previous results page."""
+  hasPreviousPage: Boolean!
+}
+
+"""
+Possible result order of searchCatalog Query. Result order `BEST_MATCH` is affected by the authenticated user.
+"""
+enum LearnEntityOrder {
+  BEST_MATCH
+  MOST_POPULAR
+  MOST_RECENT
+  TITLE_AZ
+  TITLE_ZA
+}
+
+"""A Learn Entity Response."""
+union LearnEntityResponse = LearnTutorial | LearnProject | LearnCourse | NotFoundError | ServerError
+
+"""Possible skill level values of a Learn Entity Skill Level."""
+enum LearnEntitySkillLevel {
+  FOUNDATIONAL
+  BEGINNER
+  INTERMEDIATE
+  ADVANCED
+}
+
+"""Possible topic values of a Learn Entity Topic."""
+enum LearnEntityTopic {
+  TWO_D
+  AI_AND_NAVIGATION
+  ANIMATION
+  ART
+  AUDIO
+  CAMERAS
+  DCC_TO_UNITY
+  DESIGN
+  EDITOR_ESSENTIALS
+  FOR_EDUCATORS
+  GRAPHIC_AND_VISUAL_EFFECTS
+  LIGHTING_AND_VISUAL_FIDELITY
+  MATERIAL_AND_SHADERS
+  MOBILE_AND_TOUCH
+  MODELING
+  OBJECT_AND_COMPONENTS
+  OPTIMIZATION
+  PHYSICS
+  PROJECT_MANAGEMENT
+  PROJECT_SETUP_AND_SETTINGS
+  PUBLISHING
+  RENDER_PIPELINES
+  SCRIPTING
+  UNITY_SERVICES
+  USER_INTERFACE
+  VISUALIZATION
+  XR
+}
+
+"""Possible type values of a Learn Entity Type."""
+enum LearnEntityType {
+  TUTORIAL
+  PROJECT
+  COURSE
+  ALL
+}
+
+"""A Media as defined on Learn Live Platform."""
+type LearnMedia {
+  """The URL of the Media."""
+  url: URL!
+
+  """The type of the Media."""
+  type: LearnMediaType!
+}
+
+"""Possible types of LearnMedia Type."""
+enum LearnMediaType {
+  IMAGE
+  VIDEO
+  GIF
+}
+
+"""A Learn Project."""
+type LearnProject implements LearnEntityInterface {
+  """The ID of the Learn Entity."""
+  id: ID!
+
+  """The type of the Learn Entity."""
+  type: LearnEntityType!
+
+  """The title of the Learn Entity."""
+  title: String!
+
+  """The description of the Learn Entity."""
+  description: String!
+
+  """The proprietary Draft JS JSON description of the Learn Entity."""
+  draftJSDescription: String!
+
+  """
+  The thumbnail of the Learn Entity. A fallback image is returned if no thumbnail is available.
+  """
+  thumbnail: LearnMedia!
+
+  """The language of the Learn Entity."""
+  language: LearnEntityLanguage!
+
+  """The duration in minutes of the Learn Entity."""
+  duration: LearnTimeValue!
+
+  """The total number of bookmarks of the Learn Entity."""
+  totalBookmarks: Int!
+
+  """The web URL of the Learn Entity."""
+  url: URL!
+
+  """The skill level of the Learn Entity."""
+  skillLevel: LearnEntitySkillLevel!
+
+  """The author of the Learn Entity."""
+  author: LearnEntityAuthor!
+
+  """The list of topics related to the Learn Entity."""
+  topics: [LearnEntityTopic!]!
+
+  """The list of industries related to the Learn Entity."""
+  industries: [LearnEntityIndustry!]!
+
+  """The supported Unity editor version of the Learn Entity."""
+  supportedEditorVersion: String!
+
+  """The list of learning materials related to the Learn Entity."""
+  materials: [LearnEntityMaterial!]
+
+  """The Unity Connect group of the Learn Entity."""
+  connectGroup: LearnEntityConnectGroup
+
+  """The list of tutorials related to the Learn Project."""
+  tutorials: [LearnEntityInterface!]
+}
+
+"""A Time Value as defined on Learn Live Platform."""
+type LearnTimeValue {
+  """The value of the Time Value."""
+  value: Float!
+
+  """The unit of the Time Value."""
+  unit: TimeUnit!
+}
+
+"""A Learn Tutorial."""
+type LearnTutorial implements LearnEntityInterface {
+  """The ID of the Learn Entity."""
+  id: ID!
+
+  """The type of the Learn Entity."""
+  type: LearnEntityType!
+
+  """The title of the Learn Entity."""
+  title: String!
+
+  """The description of the Learn Entity."""
+  description: String!
+
+  """The proprietary Draft JS JSON description of the Learn Entity."""
+  draftJSDescription: String!
+
+  """
+  The thumbnail of the Learn Entity. A fallback image is returned if no thumbnail is available.
+  """
+  thumbnail: LearnMedia!
+
+  """The language of the Learn Entity."""
+  language: LearnEntityLanguage!
+
+  """The duration in minutes of the Learn Entity."""
+  duration: LearnTimeValue!
+
+  """The total number of bookmarks of the Learn Entity."""
+  totalBookmarks: Int!
+
+  """The web URL of the Learn Entity."""
+  url: URL!
+
+  """The skill level of the Learn Entity."""
+  skillLevel: LearnEntitySkillLevel!
+
+  """The author of the Learn Entity."""
+  author: LearnEntityAuthor!
+
+  """The list of topics related to the Learn Entity."""
+  topics: [LearnEntityTopic!]!
+
+  """The list of industries related to the Learn Entity."""
+  industries: [LearnEntityIndustry!]!
+
+  """The supported Unity editor version of the Learn Entity."""
+  supportedEditorVersion: String!
+
+  """The list of learning materials related to the Learn Entity."""
+  materials: [LearnEntityMaterial!]
+
+  """The Unity Connect group of the Learn Entity."""
+  connectGroup: LearnEntityConnectGroup
+
+  """The list of parents related to the Learn Tutorial."""
+  parents: [LearnEntityInterface!]
+}
+
+"""The Unity Editor License information."""
+type License {
+  """The Unity Editor License type."""
+  type: LicenseType!
+
+  """The Unity Editor License activation date (Unix timestamp)."""
+  activationDate: Timestamp!
+}
+
+"""Possible types of Unity Editor License."""
+enum LicenseType {
+  ENTERPRISE
+  PERSONAL
+  PLUS
+  PRO
+}
+
+"""
+A Metered Product is one which varies in price depending on usage (for example,
+Unity Simulation - Bandwidth). It extends the `ProductInterface` by adding tiers
+of usage costs to the base type.
+"""
+type MeteredProduct implements ProductInterface {
+  """The slug of the Product."""
+  slug: ID!
+
+  """The SKU of the Product."""
+  sku: ID!
+
+  """The name of the Product."""
+  name: String!
+
+  """The type of the Product."""
+  type: ProductType!
+
+  """The description of the Product."""
+  description: String!
+
+  """The UI Page of the Product."""
+  ui: UIPage!
+
+  """The tiers of the Metered Product."""
+  tiers: [ProductVariant!]!
+}
+
+type Mutation {
+  """Create a new Organization."""
+  createOrganization(
+    """The input argument for creating an Organization."""
+    input: CreateOrganizationInput!
+  ): CreateOrganizationResponse!
+
+  """Add a bookmark to a Learn Entity for an authenticated User."""
+  addLearnEntityBookmark(
+    """The input argument for adding a bookmark to a Learn Entity."""
+    input: LearnEntityBookmarkMutationInput!
+  ): LearnEntityBookmarkMutationResponse!
+
+  """Remove a bookmark from a Learn Entity for an authenticated User."""
+  removeLearnEntityBookmark(
+    """The input argument for removing a bookmark from a Learn Entity."""
+    input: LearnEntityBookmarkMutationInput!
+  ): LearnEntityBookmarkMutationResponse!
+
+  """Send an analytics event to Heap."""
+  sendHeapAnalyticsEvent(
+    """The input argument for sending a Heap Analytics event."""
+    input: SendHeapAnalyticsEventInput!
+  ): SendHeapAnalyticsEventResponse!
+}
+
+"""A NotFound Error is returned when an entity cannot be retrieved."""
+type NotFoundError implements Error {
+  """The title of the Error."""
+  title: String!
+
+  """The message of the Error."""
+  message: String!
+
+  """The errorCode of the Error."""
+  errorCode: String!
+}
+
+"""
+A One Time Product is one where a consumer pays a single lump sum for the
+product (for example, Unity Certified Professional: Artist). It extends the
+`ProductInterface` by adding a single price field informing how much a customer needs to pay.
+"""
+type OneTimeProduct implements ProductInterface {
+  """The slug of the Product."""
+  slug: ID!
+
+  """The SKU of the Product."""
+  sku: ID!
+
+  """The name of the Product."""
+  name: String!
+
+  """The type of the Product."""
+  type: ProductType!
+
+  """The description of the Product."""
+  description: String!
+
+  """The UI Page of the Product."""
+  ui: UIPage!
+
+  """The price of the One Time Product."""
+  price: Price!
+}
+
+"""An Organization."""
+type Organization {
+  """The unique id of the Organization."""
+  id: ID!
+
+  """The name of the Organization."""
+  name: String!
+
+  """The primary address of the Organization."""
+  primaryAddress: OrganizationAddress
+
+  """The role of the user in the Organization."""
+  role: OrganizationRole!
+}
+
+"""The Address of the Organization."""
+type OrganizationAddress {
+  """The unique id of the Organization Address."""
+  id: ID!
+
+  """The street of the Organization Address."""
+  street: String!
+
+  """The city of the Organization Address."""
+  city: String!
+
+  """The postal code of the Organization Address."""
+  postalCode: String!
+
+  """The country of the Organization Address."""
+  country: String!
+
+  """The state of the Organization Address."""
+  state: String
+
+  """The phone number of the Organization Address."""
+  phoneNumber: String
+
+  """The company name of the Organization Address."""
+  companyName: String @deprecated(reason: "This field is deprecated. Please use the Organization `name` instead.")
+}
+
+"""Possible types of Organization Role."""
+enum OrganizationRole {
+  MANAGER
+  OWNER
+  USER
+  GUEST
+}
+
+"""A Price related to a Product."""
+type Price {
+  """The value of the Price."""
+  value: Float!
+
+  """The currency of the Price."""
+  currency: Currency!
+}
+
+"""A Product Interface returned from the product queries."""
+interface ProductInterface {
+  """The slug of the Product."""
+  slug: ID!
+
+  """The SKU of the Product."""
+  sku: ID!
+
+  """The name of the Product."""
+  name: String!
+
+  """The type of the Product."""
+  type: ProductType!
+
+  """The description of the Product."""
+  description: String!
+
+  """The UI Page of the Product."""
+  ui: UIPage!
+}
+
+"""A Product Response."""
+union ProductResponse = MeteredProduct | SubscriptionProduct | OneTimeProduct | CompositeMeteredProduct | ServerError | NotFoundError
+
+"""Possible types of Product."""
+enum ProductType {
+  COMPOSITE_METERED
+  METERED
+  SUBSCRIPTION
+  ONE_TIME
+}
+
+"""A Product Variant."""
+union ProductVariant = FlatVariant | UnitVariant
+
+type Query {
+  """Get the Authenticated User profile and the associated resources."""
+  getAuthenticatedUser: User!
+
+  """Search for learn content within the Unity Learn catalog."""
+  searchLearnCatalog(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+
+    """
+    Searches for specific terms (e.g. 3D, platforms, C#). Unsupported characters will be removed from the terms.
+    """
+    searchTerms: String
+
+    """Filters by Learn Entity Skill Level."""
+    skillLevels: [LearnEntitySkillLevel!] = []
+
+    """Filters by Learn Entity TYpe."""
+    types: [LearnEntityType!] = [ALL]
+
+    """Filters by Learn Entity Topic."""
+    topics: [LearnEntityTopic!] = []
+
+    """Filters by Learn Entity Industry."""
+    industries: [LearnEntityIndustry!] = []
+
+    """Filters by Learn Entity Duration."""
+    durations: [LearnEntityDuration!] = []
+
+    """Filters by Learn Entity Language."""
+    languages: [LearnEntityLanguage!] = []
+
+    """Orders the returned results by Learn Entity Order."""
+    order: LearnEntityOrder = BEST_MATCH
+  ): LearnEntityOffsetConnection!
+
+  """Get the HUB featured learn content from the Unity Learn catalog."""
+  getHubFeaturedLearnEntities(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+  ): LearnEntityOffsetConnection!
+
+  """Get the Learn Entity from the Unity Learn catalog."""
+  getLearnEntity(
+    """The ID of the Learn Entity."""
+    id: ID!
+
+    """The type of the Learn Entity."""
+    type: LearnEntityType!
+  ): LearnEntityResponse!
+
+  """Get a Product by SKU."""
+  getProduct(
+    """The SKU of the Product Entity."""
+    sku: ID!
+  ): ProductResponse! @deprecated(reason: "Retrieving a product by SKU is deprecated; please use 'getProductBySlug' instead.")
+
+  """Get all Templates within the Live Platform service."""
+  getTemplates(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+
+    """Orders the returned results by Get Templates Order."""
+    orderBy: TemplateOrder = WEIGHTED_DESC
+
+    """Filters by Template Type."""
+    type: TemplateType
+
+    """Filters by Template Category."""
+    category: [TemplateCategory!] = []
+
+    """Filters by Template Unity Supported Version."""
+    unitySupportedVersion: [String!] = []
+
+    """Filters by Template Version Supported Unity Editor Versions."""
+    supportedUnityEditorVersions: [String!] = []
+  ): TemplateOffsetConnection!
+
+  """Get all the Hub Content Categories within the Live Platform service."""
+  getHubContentCategories(
+    """Orders the returned results by Get Hub Content Categories Order."""
+    orderBy: HubContentCategoryOrder = WEIGHTED_DESC
+  ): [HubContentCategory!]!
+
+  """
+  Get all Unity Hub Community Resources within the Live Platform service.
+  """
+  getHubCommunityResources(
+    """Orders the returned results by Hub Community Resources Order."""
+    orderBy: CommunityResourceOrder = WEIGHTED_DESC
+  ): [CommunityResource!]! @deprecated(reason: "Retrieving Unity Hub Community Resources with this query is deprecated; please use getHubContentCategories.")
+
+  """Get all Weta Releases within the Live Platform service."""
+  getWetaReleases(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+
+    """Orders the returned results by Get Weta Releases Order."""
+    orderBy: WetaReleaseOrder = RELEASE_DATE_DESC
+
+    """Filters by Weta Release product name."""
+    productName: [WetaReleaseProductName!] = []
+
+    """Filters by a full text search on the version string."""
+    version: String
+  ): WetaReleaseOffsetConnection!
+
+  """Get all Unity Releases within the Live Platform service."""
+  getUnityReleases(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+
+    """Orders the returned results by Get Unity Releases Order."""
+    orderBy: UnityReleaseOrder = RELEASE_DATE_DESC
+
+    """Filters by Unity Release stream."""
+    stream: [UnityReleaseStream!] = []
+
+    """Filters by Unity Release download platform."""
+    platform: [UnityReleaseDownloadPlatform!] = []
+
+    """Filters by Unity Release download architecture."""
+    architecture: [UnityReleaseDownloadArchitecture!] = []
+
+    """Filters by a full text search on the version string."""
+    version: String
+  ): UnityReleaseOffsetConnection!
+
+  """Get all Unity Release Major Versions within the Live Platform service."""
+  getUnityReleaseMajorVersions(
+    """Filters by Unity Release stream."""
+    stream: [UnityReleaseStream!] = []
+
+    """Filters by Unity Release download platform."""
+    platform: [UnityReleaseDownloadPlatform!] = []
+
+    """Filters by Unity Release download architecture."""
+    architecture: [UnityReleaseDownloadArchitecture!] = []
+  ): [UnityReleaseMajorVersion!]!
+}
+
+"""Possible types of Release Digital Unit."""
+enum ReleaseDigitalUnit {
+  BYTE
+  KILOBYTE
+  MEGABYTE
+  GIGABYTE
+}
+
+"""A Digital Value as defined on Release Live Platform."""
+type ReleaseDigitalValue {
+  """The value of the Digital Value."""
+  value: Float!
+
+  """The unit of the Digital Value."""
+  unit: ReleaseDigitalUnit!
+}
+
+"""A Media as defined on Resource Live Platform."""
+type ResourceMedia {
+  """The URL of the Media."""
+  url: URL!
+
+  """The type of the Media."""
+  type: ResourceMediaType!
+}
+
+"""Possible types of ResourceMedia Type."""
+enum ResourceMediaType {
+  IMAGE
+  VIDEO
+  GIF
+}
+
+"""Input Fields to send a Heap Analytics Event."""
+input SendHeapAnalyticsEventInput {
+  """The Heap app_id which links this tracking event to a Heap Project."""
+  appId: ID!
+
+  """The identity of the user which emitted the event."""
+  identity: String!
+
+  """The name of the event. Should correlate to the Heap definition."""
+  event: String!
+
+  """The time at which an event occurred (Unix timestamp)."""
+  timestamp: Timestamp
+
+  """The properties of an event."""
+  properties: JSONObject
+}
+
+"""The response from a Send Heap Analytics Event."""
+union SendHeapAnalyticsEventResponse = SendHeapAnalyticsEventResult | ServerError
+
+"""The result for the Send Heap Analytics Event mutation."""
+type SendHeapAnalyticsEventResult {
+  """The indication whether Heap Analytics event was sent or not."""
+  success: Boolean!
+}
+
+"""
+A ServerError is returned when the Live Platform throws an unhandled or operational error.
+"""
+type ServerError implements Error {
+  """The title of the Error."""
+  title: String!
+
+  """The message of the Error."""
+  message: String!
+
+  """The errorCode of the Error."""
+  errorCode: String!
+}
+
+"""
+Subresource Integrity scalar type. It represents SRI values as defined by the
+[W3C Recommendation Subresource Integrity](https://www.w3.org/TR/SRI/). It is of
+type JSON string when used in inputs and response data.
+"""
+scalar SubresourceIntegrity
+
+"""
+A Subscription Product is one where a consumer pays a set amount each month for
+continued usage of the product (for example, Unity Pro). It extends the
+`ProductInterface` by adding variants for different kinds of subscriptions (e.g.
+monthly,yearly).
+"""
+type SubscriptionProduct implements ProductInterface {
+  """The slug of the Product."""
+  slug: ID!
+
+  """The SKU of the Product."""
+  sku: ID!
+
+  """The name of the Product."""
+  name: String!
+
+  """The type of the Product."""
+  type: ProductType!
+
+  """The description of the Product."""
+  description: String!
+
+  """The UI Page of the Product."""
+  ui: UIPage!
+
+  """The variants of the Subscription Product."""
+  variants: [ProductVariant!]!
+
+  """The payment plan name of the Subscription Product."""
+  paymentPlan: String!
+}
+
+"""A Template."""
+type Template {
+  """The package name, that uniquely identifies the Template."""
+  packageName: String!
+
+  """The human-readable name of the Template."""
+  name: String!
+
+  """The description of the Template."""
+  description: String!
+
+  """The icon of the Template."""
+  icon: TemplateMedia!
+
+  """The preview image of the Template."""
+  previewImage: TemplateMedia!
+
+  """The type of the Template."""
+  type: TemplateType!
+
+  """The category of the Template."""
+  category: TemplateCategory!
+
+  """The terms of service of the Template."""
+  termsOfService: TemplateFile
+
+  """The extra fields defined on the Template."""
+  extraFields: [ExtraField!]
+
+  """The render pipeline of the Template."""
+  renderPipeline: TemplateRenderPipeline!
+
+  """The versions of the Template."""
+  versions: [TemplateVersion!]!
+
+  """The build platform of the Template."""
+  buildPlatform: TemplateBuildPlatform! @deprecated(reason: "This field is deprecated. Please use 'buildPlatforms' instead.")
+
+  """The build platforms of the Template."""
+  buildPlatforms: [TemplateBuildPlatform!]!
+
+  """The list of Unity supported editor version for the Template."""
+  unitySupportedVersions: [String!]! @deprecated(reason: "This is no longer used. Please use the 'supportedUnityEditorVersions' field instead.")
+
+  """The indicator for whether a Template is a new Template."""
+  isNew: Boolean!
+}
+
+"""Possible types of a Template Build Platform."""
+enum TemplateBuildPlatform {
+  IOS
+  ANDROID
+  TVOS
+  LINUX
+  MACOS
+  WEBGL
+  WINDOWS
+  LUMINOS
+}
+
+"""Possible categories of a Template."""
+enum TemplateCategory {
+  BLANK
+  XR
+  AEC
+  AUTOMOTIVE
+  MNE
+  GAME
+  ART
+}
+
+"""A Template Dependency."""
+type TemplateDependency {
+  """The name of the Template Dependency."""
+  name: String!
+
+  """The package name of the Template Dependency."""
+  packageName: String!
+
+  """The version of the Template Dependency."""
+  version: String!
+}
+
+"""Possible types of Template Digital Unit."""
+enum TemplateDigitalUnit {
+  BYTE
+  KILOBYTE
+  MEGABYTE
+  GIGABYTE
+}
+
+"""A Digital Value as defined on Template Live Platform."""
+type TemplateDigitalValue {
+  """The value of the Digital Value."""
+  value: Float!
+
+  """The unit of the Digital Value."""
+  unit: TemplateDigitalUnit!
+}
+
+"""A File as defined on Template Live Platform."""
+type TemplateFile {
+  """The url of the File."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the File as defined by the [W3C Recommendation
+  Subresource Integrity](https://www.w3.org/TR/SRI/). For example,
+  `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity!
+
+  """The checksum of the File."""
+  checksum: String! @deprecated(reason: "This has been replaced by the field `integrity`. Please use that instead.")
+
+  """The type of the File."""
+  type: FileType!
+}
+
+"""A Media as defined on Template Live Platform."""
+type TemplateMedia {
+  """The URL of the Media."""
+  url: URL!
+
+  """The type of the Media."""
+  type: TemplateMediaType!
+}
+
+"""Possible types of TemplateMedia Type."""
+enum TemplateMediaType {
+  IMAGE
+  VIDEO
+  GIF
+}
+
+"""A relay style offset paginated Template Connection."""
+type TemplateOffsetConnection {
+  """The list of offset paginated Template edges."""
+  edges: [TemplateOffsetEdge!]!
+
+  """The total count of all available Template edges in the connection."""
+  totalCount: Int!
+
+  """The page information for offset pagination."""
+  pageInfo: TemplateOffsetPageInfo!
+}
+
+"""A relay style offset paginated Template Edge."""
+type TemplateOffsetEdge {
+  """A Template node."""
+  node: Template!
+}
+
+"""The Template Offset Pagination Information related to a connection."""
+type TemplateOffsetPageInfo {
+  """The flag indicating if there is a next results page."""
+  hasNextPage: Boolean!
+
+  """The flag indicating if there is a previous results page."""
+  hasPreviousPage: Boolean!
+}
+
+"""Possible values of Template Order."""
+enum TemplateOrder {
+  NAME_ASC
+  NAME_DESC
+  WEIGHTED_DESC
+  RELEASE_DATE_ASC
+  RELEASE_DATE_DESC
+}
+
+"""Possible render pipelines of a Template."""
+enum TemplateRenderPipeline {
+  URP
+  SRP
+  HDRP
+  BUILT_IN
+}
+
+"""Possible values of Template Type."""
+enum TemplateType {
+  LEARNING
+  CORE
+  SAMPLE
+}
+
+"""A Template Version."""
+type TemplateVersion {
+  """The name of the Template Version."""
+  name: String!
+
+  """The size of the Template Version."""
+  size(
+    """The format of the Template Digital Value size."""
+    format: TemplateDigitalUnit! = BYTE
+  ): TemplateDigitalValue!
+
+  """The tarball of the Template Version."""
+  tarball: TemplateFile!
+
+  """The field describing if the Template Version is the most up-to-date."""
+  isLatest: Boolean!
+
+  """The unity editor target for the Template Version."""
+  unityEditorTarget: String! @deprecated(reason: "This should not be used. Please use the 'supportedUnityEditorVersions' field instead.")
+
+  """The supported Unity Editor versions for the Template Version."""
+  supportedUnityEditorVersions: [String!]!
+
+  """The list of dependencies for the Template Version."""
+  dependencies: [TemplateDependency!]!
+}
+
+"""
+The javascript `Date` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch.
+"""
+scalar Timestamp
+
+"""Possible types of Time Unit."""
+enum TimeUnit {
+  SECOND
+  MINUTE
+  HOUR
+  DAY
+}
+
+"""Possible values of Component Alignment."""
+enum UIAlignment {
+  LEFT
+  RIGHT
+  CENTER
+}
+
+"""A UI body."""
+type UIBody {
+  """The elements of the UI body."""
+  elements: [UIElement!]!
+}
+
+"""A UI Component call to action."""
+type UICallToAction implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The action type of the Call to Action component."""
+  actionType: UICallToActionType!
+
+  """The target of the Call to Action component."""
+  target: String!
+
+  """The label of the Call to Action component."""
+  label: String!
+}
+
+"""Possible values of Call to Action type."""
+enum UICallToActionType {
+  BUTTON
+  LINK
+}
+
+"""A UI Common Component."""
+interface UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+}
+
+"""A UI Component."""
+union UIComponent = UITitle | UISubTitle | UIParagraph | UITable | UICallToAction | UIImage | UIVideo | UITextBlock
+
+"""A set of UI Components."""
+type UIComponents {
+  """A UI Component pricing table response."""
+  pricingTable(
+    """
+    The name of the pricing table template to render. If not specified, the default template (if it exists) is rendered.
+    """
+    name: String
+  ): UITableResponse
+}
+
+"""Possible values of Component type."""
+enum UIComponentType {
+  TITLE
+  SUBTITLE
+  PARAGRAPH
+  TABLE
+  CALL_TO_ACTION
+  IMAGE
+  VIDEO
+  TEXT_BLOCK
+}
+
+"""A UI Element."""
+union UIElement = UIRow | UIHeroBanner
+
+"""Possible values of UI Element type."""
+enum UIElementType {
+  HERO_BANNER
+  ONE_COLUMN
+  TWO_COLUMN
+  THREE_COLUMN
+}
+
+"""A UI Hero Banner."""
+type UIHeroBanner {
+  """The element type of the UI Hero Banner."""
+  type: UIElementType
+
+  """The Title of the UI Hero Banner."""
+  title: UITitle!
+
+  """The paragraph of the UI Hero Banner."""
+  paragraph: UIParagraph!
+
+  """The background image of the UI Hero Banner."""
+  backgroundImage: UIImage!
+
+  """The Call to Action of the UI Hero Banner."""
+  callToAction: UICallToAction!
+}
+
+"""A UI Component image."""
+type UIImage implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The url of the Image component."""
+  url: URL!
+}
+
+"""A UI Page metadata."""
+type UIMetadata {
+  """The title of the UI Page metadata."""
+  title: String!
+
+  """UI Component pricing table template names for the associated slug."""
+  pricingTableTemplateNames: [String!]!
+}
+
+"""A UI Page."""
+type UIPage {
+  """The metadata of the UI Page."""
+  metadata: UIMetadata
+
+  """The body of the UI Page."""
+  body: UIBody
+
+  """The UI Components."""
+  components: UIComponents
+}
+
+"""A UI Component paragraph."""
+type UIParagraph implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The text content of the Paragraph component."""
+  text: String!
+}
+
+"""A UI Row."""
+type UIRow {
+  """The element type of the UI Row."""
+  type: UIElementType
+
+  """The components of the UI Row."""
+  components: [UIComponent!]!
+}
+
+"""A UI Component sub title."""
+type UISubTitle implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The text content of the SubTitle component."""
+  text: String!
+}
+
+"""A UI Component table."""
+type UITable implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the Table component."""
+  alignment: UIAlignment!
+
+  """The title of the Table component."""
+  title: UITitle
+
+  """The headers of the Table component."""
+  headers: [String!]!
+
+  """The rows of the Table component."""
+  rows: [UITableRow!]!
+}
+
+"""A UI Table Response."""
+union UITableResponse = UITable | ServerError
+
+"""A UI Table Component row."""
+type UITableRow {
+  """The columns of the Table Row component."""
+  columns: [String!]!
+}
+
+"""A UI Component text block."""
+type UITextBlock implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The title of the Text Block component."""
+  title: UITitle!
+
+  """The paragraph of the Text Block component."""
+  paragraph: UIParagraph!
+
+  """The optional call to action of the Text Block component."""
+  callToAction: UICallToAction
+}
+
+"""A UI Component title."""
+type UITitle implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The text content of the Title component."""
+  text: String!
+}
+
+"""A UI Component video."""
+type UIVideo implements UICommonComponent {
+  """The type of the component."""
+  type: UIComponentType!
+
+  """The alignment of the component."""
+  alignment: UIAlignment!
+
+  """The url of the Video component."""
+  url: URL!
+
+  """The preview image of the Video component."""
+  previewImage: UIImage!
+}
+
+"""A Pay per Unit pricing for Product."""
+type UnitVariant {
+  """The id of the Unit Variant."""
+  id: ID!
+
+  """The name of the Unit Variant."""
+  name: String!
+
+  """The price of the Unit Variant."""
+  price: Price!
+
+  """The unit of the Unit Variant."""
+  unit: String!
+
+  """The boundary values of the Unit Variant if they exist."""
+  boundary: Boundary
+}
+
+"""A Unity Release."""
+type UnityRelease {
+  """The version of the Unity Release."""
+  version: ID!
+
+  """The release date of the Unity Release."""
+  releaseDate: DateTime!
+
+  """The release notes of the Unity Release."""
+  releaseNotes: UnityReleaseNotes!
+
+  """The release stream of the Unity Release."""
+  stream: UnityReleaseStream!
+
+  """The downloads of the Unity Release."""
+  downloads: [UnityReleaseDownload!]!
+
+  """The SKU family of the Unity Release."""
+  skuFamily: UnityReleaseSkuFamily!
+
+  """
+  The indicator for whether the Unity Release is the recommended LTS version.
+  """
+  recommended: Boolean!
+
+  """The Unity Hub deep link of the Unity Release."""
+  unityHubDeepLink: URL!
+
+  """The Git Short Revision of the Unity Release."""
+  shortRevision: String!
+
+  """The Third Party Notices of the Unity Release."""
+  thirdPartyNotices: [UnityReleaseThirdPartyNotice!]!
+}
+
+"""A Unity Release download."""
+union UnityReleaseDownload = UnityReleaseHubDownload
+
+"""Possible architectures of Unity Release download."""
+enum UnityReleaseDownloadArchitecture {
+  X86_64
+  ARM64
+}
+
+"""Possible platforms of Unity Release download."""
+enum UnityReleaseDownloadPlatform {
+  MAC_OS
+  LINUX
+  WINDOWS
+}
+
+"""A File as defined on Release Live Platform."""
+interface UnityReleaseFile {
+  """The URL of the File."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the File as defined by the [W3C Recommendation
+  Subresource Integrity](https://www.w3.org/TR/SRI/). For example,
+  `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The type of the File."""
+  type: FileType!
+}
+
+"""A Unity Release Hub download."""
+type UnityReleaseHubDownload implements UnityReleaseFile {
+  """The URL of the Unity Release Hub download."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the Unity Release Hub download as defined by the
+  [W3C Recommendation Subresource Integrity](https://www.w3.org/TR/SRI/). For
+  example, `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The file type of the Unity Release Hub download."""
+  type: FileType!
+
+  """The platform of the Unity Release Hub download."""
+  platform: UnityReleaseDownloadPlatform!
+
+  """The architecture of the Unity Release Hub download."""
+  architecture: UnityReleaseDownloadArchitecture!
+
+  """The modules of the Unity Release Hub download."""
+  modules: [UnityReleaseModule!]!
+
+  """The download size of the Unity Release Hub download."""
+  downloadSize(
+    """The format of the Release Digital Value size."""
+    format: ReleaseDigitalUnit! = BYTE
+  ): ReleaseDigitalValue!
+
+  """The installed size of the Unity Release Hub download."""
+  installedSize(
+    """The format of the Release Digital Value size."""
+    format: ReleaseDigitalUnit! = BYTE
+  ): ReleaseDigitalValue!
+}
+
+"""A Unity Release Major Version."""
+type UnityReleaseMajorVersion {
+  """The version of the Unity Release Major Version."""
+  version: String!
+
+  """The latest Unity Release of the Unity Release Major Version."""
+  latestUnityRelease: UnityRelease!
+}
+
+"""A Unity Release module."""
+type UnityReleaseModule implements UnityReleaseFile {
+  """The URL of the Unity Release module."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the Unity Release module as defined by the [W3C
+  Recommendation Subresource Integrity](https://www.w3.org/TR/SRI/). For
+  example, `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The file type of the Unity Release module."""
+  type: FileType!
+
+  """The ID of the Unity Release module."""
+  id: ID!
+
+  """
+  The slug of the Unity Release module. This is unique across all Unity Release Modules.
+  """
+  slug: ID!
+
+  """The name of the Unity Release module."""
+  name: String!
+
+  """The description of the Unity Release module."""
+  description: String!
+
+  """The category of the Unity Release module."""
+  category: UnityReleaseModuleCategory!
+
+  """
+  The optional sub-modules of the Unity Release module. The parent must be downloaded to download a sub-module.
+  """
+  subModules: [UnityReleaseModule!]
+
+  """
+  The indicator for whether the Unity Release module needs to be downloaded if the parent is downloaded.
+  """
+  required: Boolean!
+
+  """
+  The indicator for whether the Unity Release module needs to be hidden when displaying modules in a UI.
+  """
+  hidden: Boolean!
+
+  """
+  The location to move a Unity Release Module when extracted or unzipped.
+  """
+  extractedPathRename: UnityReleaseModuleExtractedPathRename
+
+  """
+  The indicator for whether the Unity Release module should be pre-selected.
+  """
+  preSelected: Boolean!
+
+  """The file destination of the Unity Release module."""
+  destination: String
+
+  """The end-user license agreements of the Unity Release module."""
+  eula: [UnityReleaseModuleEula!]
+
+  """The download size of the Unity Release module."""
+  downloadSize(
+    """The format of the Release Digital Value size."""
+    format: ReleaseDigitalUnit! = BYTE
+  ): ReleaseDigitalValue!
+
+  """The installed size of the Unity Release module."""
+  installedSize(
+    """The format of the Release Digital Value size."""
+    format: ReleaseDigitalUnit! = BYTE
+  ): ReleaseDigitalValue!
+}
+
+"""Possible categories of Unity Release module."""
+enum UnityReleaseModuleCategory {
+  DOCUMENTATION
+  PLATFORM
+  LANGUAGE_PACK
+  DEV_TOOL
+  PLUGIN
+  COMPONENT
+}
+
+"""A Unity Release module end-user license agreement."""
+type UnityReleaseModuleEula implements UnityReleaseFile {
+  """The URL of the Unity Release module end-user license agreement."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the Unity Release module end-user license
+  agreement as defined by the [W3C Recommendation Subresource
+  Integrity](https://www.w3.org/TR/SRI/). For example,
+  `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The file type of the Unity Release module end-user license agreement."""
+  type: FileType!
+
+  """The label of the Unity Release module end-user license agreement."""
+  label: String!
+
+  """The message of the Unity Release module end-user license agreement."""
+  message: String!
+}
+
+"""A Unity Release Module Extracted Path Rename."""
+type UnityReleaseModuleExtractedPathRename {
+  """The location of the module when extracted."""
+  from: String!
+
+  """The location the module must be moved to."""
+  to: String!
+}
+
+"""A Unity Release Notes File as defined on Release Live Platform."""
+type UnityReleaseNotes implements UnityReleaseFile {
+  """The URL of the Unity Release notes."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the Unity Release notes as defined by the [W3C
+  Recommendation Subresource Integrity](https://www.w3.org/TR/SRI/). For
+  example, `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The file type of the Unity Release notes."""
+  type: FileType!
+}
+
+"""A relay style offset paginated Unity Release Connection."""
+type UnityReleaseOffsetConnection {
+  """The list of offset paginated Unity Release edges."""
+  edges: [UnityReleaseOffsetEdge!]!
+
+  """
+  The total count of all available Unity Release edges in the connection.
+  """
+  totalCount: Int!
+
+  """The page information for offset pagination."""
+  pageInfo: UnityReleaseOffsetPageInfo!
+}
+
+"""A relay style offset paginated Unity Release Edge."""
+type UnityReleaseOffsetEdge {
+  """An Unity Release node."""
+  node: UnityRelease!
+}
+
+"""
+The UnityRelease Offset Pagination Information related to a connection.
+"""
+type UnityReleaseOffsetPageInfo {
+  """The flag indicating if there is a next results page."""
+  hasNextPage: Boolean!
+
+  """The flag indicating if there is a previous results page."""
+  hasPreviousPage: Boolean!
+}
+
+"""Possible values of Unity Release Order."""
+enum UnityReleaseOrder {
+  RELEASE_DATE_ASC
+  RELEASE_DATE_DESC
+}
+
+"""Possible SKU families of Unity Release."""
+enum UnityReleaseSkuFamily {
+  DOTS
+  CLASSIC
+}
+
+"""Possible release streams of Unity Release."""
+enum UnityReleaseStream {
+  LTS
+  BETA
+  ALPHA
+  TECH
+}
+
+"""
+A Unity Release Third Party Notice File as defined on Release Live Platform.
+"""
+type UnityReleaseThirdPartyNotice implements UnityReleaseFile {
+  """The URL of the Unity Release Third Party Notice."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the Unity Release Third Party Notice as defined
+  by the [W3C Recommendation Subresource Integrity](https://www.w3.org/TR/SRI/).
+  For example, `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The file type of the Unity Release Third Party Notice."""
+  type: FileType!
+
+  """The original file name of the Unity Release Third Party Notice."""
+  originalFileName: String!
+}
+
+"""
+A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt.
+"""
+scalar URL
+
+"""An authenticated User."""
+type User {
+  """The unique UnityId of the User."""
+  unityId: ID!
+
+  """The preferred language code of the User."""
+  language: String!
+
+  """The full name of the User."""
+  fullName: String!
+
+  """The username of the User."""
+  username: String!
+
+  """The email address of the User."""
+  email: EmailAddress!
+
+  """The date and time the user’s account was created."""
+  createdTime: DateTime!
+
+  """
+  The flag for a new user. It's set to `true` if the user has been created in the last 24 hours.
+  """
+  isNew: Boolean!
+
+  """The Unity Editor license entitled to the User."""
+  license: License!
+
+  """
+  The URL to the Unity Connect avatar of the User. A fallback image is returned if no user avatar is available.
+  """
+  avatar: UserMedia!
+
+  """The list of the organizations for the User."""
+  organizations(
+    """The role of the user in the Organization."""
+    roles: [OrganizationRole!] = []
+  ): [Organization!]!
+
+  """
+  Gets the user's list of recommended learn content from the Unity Learn catalog.
+  """
+  recommendedLearnEntities(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+  ): LearnEntityOffsetConnection!
+
+  """
+  Gets the user's list of in-progress learn content from the Unity Learn catalog.
+  """
+  activeLearnEntities(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+  ): LearnEntityOffsetConnection!
+
+  """
+  Gets the user's list of completed learn content from the Unity Learn catalog.
+  """
+  completedLearnEntities(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+  ): LearnEntityOffsetConnection!
+
+  """
+  Gets the user's list of bookmarked learn content from the Unity Learn catalog.
+  """
+  bookmarkedLearnEntities(
+    """Limits the number of results returned per page (min 1, max 25)."""
+    limit: Int! = 10
+
+    """Skips the first n elements from the results."""
+    skip: Int! = 0
+  ): LearnEntityOffsetConnection!
+}
+
+"""A Media as defined on User Live Platform."""
+type UserMedia {
+  """The URL of the Media."""
+  url: URL!
+
+  """The type of the Media."""
+  type: UserMediaType!
+}
+
+"""Possible types of UserMedia Type."""
+enum UserMediaType {
+  IMAGE
+  VIDEO
+  GIF
+}
+
+"""A Weta Release."""
+type WetaRelease {
+  """The version of the Weta Release."""
+  version: ID!
+
+  """The release date of the Weta Release."""
+  releaseDate: DateTime!
+
+  """The release notes of the Weta Release."""
+  releaseNotes: WetaReleaseNotes!
+
+  """The installer download URL of the Weta Release."""
+  installer: URL!
+
+  """The product name of the Weta Release."""
+  productName: WetaReleaseProductName!
+}
+
+"""A File as defined on Release Live Platform."""
+interface WetaReleaseFile {
+  """The URL of the File."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the File as defined by the [W3C Recommendation
+  Subresource Integrity](https://www.w3.org/TR/SRI/). For example,
+  `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The type of the File."""
+  type: FileType!
+}
+
+"""A Weta Release Notes File as defined on Release Live Platform."""
+type WetaReleaseNotes implements WetaReleaseFile {
+  """The URL of the Weta Release notes."""
+  url: URL!
+
+  """
+  The Subresource Integrity of the Weta Release notes as defined by the [W3C
+  Recommendation Subresource Integrity](https://www.w3.org/TR/SRI/). For
+  example, `sha1-OTVjZTI0ZTk5MDg0YTMyYTBmZTdiNTU1NTMwZGRhYjQ3OWMzYzc1MQo=`.
+  """
+  integrity: SubresourceIntegrity
+
+  """The file type of the Weta Release notes."""
+  type: FileType!
+}
+
+"""A relay style offset paginated Weta Release Connection."""
+type WetaReleaseOffsetConnection {
+  """The list of offset paginated Weta Release edges."""
+  edges: [WetaReleaseOffsetEdge!]!
+
+  """The total count of all available Weta Release edges in the connection."""
+  totalCount: Int!
+
+  """The page information for offset pagination."""
+  pageInfo: WetaReleaseOffsetPageInfo!
+}
+
+"""A relay style offset paginated Weta Release Edge."""
+type WetaReleaseOffsetEdge {
+  """A Weta Release node."""
+  node: WetaRelease!
+}
+
+"""The WetaRelease Offset Pagination Information related to a connection."""
+type WetaReleaseOffsetPageInfo {
+  """The flag indicating if there is a next results page."""
+  hasNextPage: Boolean!
+
+  """The flag indicating if there is a previous results page."""
+  hasPreviousPage: Boolean!
+}
+
+"""Possible values of Weta Release Order."""
+enum WetaReleaseOrder {
+  RELEASE_DATE_ASC
+  RELEASE_DATE_DESC
+}
+
+"""Possible product names of Weta Release."""
+enum WetaReleaseProductName {
+  EDDY
+  DEEP_COMPOSITING
+  WIG
+  SPEEDTREE
+  SPEEDTREE_GAMES
+  SPEEDTREE_CINEMA
+  ZIVA_VFX
+  ZIVA_RT
+  ZIVA_FACE_TRAINER
+}
+

--- a/uvm_live_platform/src/api/list_versions.rs
+++ b/uvm_live_platform/src/api/list_versions.rs
@@ -1,0 +1,277 @@
+use serde::{Serialize, Deserialize};
+
+use crate::{UnityReleaseStream, UnityReleaseDownloadPlatform, UnityReleaseDownloadArchitecture, Result, error::LivePlatformError};
+
+#[derive(Debug)]
+pub struct ListVersions(std::vec::IntoIter<String>);
+
+impl Iterator for ListVersions {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl ListVersions {
+    pub fn builder() -> ListVersionsBuilder {
+        ListVersionsBuilder::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ListVersionsBuilder {
+    architecture: UnityReleaseDownloadArchitecture,
+    platform: UnityReleaseDownloadPlatform,
+    skip: usize,
+    limit: usize,
+    stream: UnityReleaseStream,
+    include_revision: bool,
+    autopage: bool,
+}
+
+impl ListVersionsBuilder {
+    fn new() -> Self {
+        Self {
+            architecture: Default::default(),
+            platform: Default::default(),
+            skip: Default::default(),
+            limit: 100,
+            stream: Default::default(),
+            include_revision: false,
+            autopage: false,
+        }
+    }
+
+    pub fn list(self) -> Result<ListVersions> {
+        let mut result = vec![];
+        let mut p = self.send()?;
+    
+        loop {
+            result.append(&mut p.content);
+            if self.autopage && p.has_next_page() {
+                p = p.next_page().expect("next page")?;
+            } else {
+                break;
+            }
+        }
+    
+        Ok(ListVersions(result.into_iter())) 
+    } 
+
+    fn send(self) -> Result<ListVersionsPageResult> {
+        let url = "https://live-platform-api.prd.ld.unity3d.com/graphql";
+        let request_body = UnityReleaseDownloadGetUnityReleasesRequestBody::new(self.into());
+        let client = reqwest::blocking::Client::new();
+        let res: UnityReleaseDownloadGetUnityReleasesResultBody = client
+            .post(url)
+            .json(&request_body)
+            .send()
+            .map_err(|err| LivePlatformError {
+                msg: "Call to LivePlatform service failed".to_string(),
+                source: err.into(),
+            })?
+            .json()
+            .map_err(|err| LivePlatformError {
+                msg: "Json serialization failed".to_string(),
+                source: err.into(),
+            })?;
+        let page_info = res.data.get_unity_releases.page_info;
+        let versions = res.data.get_unity_releases.edges.iter().map(|e| {
+            if self.include_revision {
+                format!("{} ({})", e.node.version, e.node.short_revision)
+            } else {
+                e.node.version.to_string()
+            }
+        });
+
+        let next_page_call = if page_info.has_next_page {
+            let mut b = self.clone();
+            b = self.skip(b.skip.checked_add(b.limit).unwrap_or(usize::MAX));
+            Some(b)
+        } else {
+            None
+        };
+
+        let r = ListVersionsPageResult::new(versions, next_page_call);
+        Ok(r)
+    }
+
+    pub fn architecture(mut self, architecture: UnityReleaseDownloadArchitecture) -> Self {
+        self.architecture = architecture;
+        self
+    }
+
+    pub fn platform(mut self, platform: UnityReleaseDownloadPlatform) -> Self {
+        self.platform = platform;
+        self
+    }
+
+    pub fn skip(mut self, skip: usize) -> Self {
+        self.skip = skip;
+        self
+    }
+
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    pub fn stream(mut self, stream: UnityReleaseStream) -> Self {
+        self.stream = stream;
+        self
+    }
+
+    pub fn include_revision(mut self, include_revision: bool) -> Self {
+        self.include_revision = include_revision;
+        self
+    }
+
+    pub fn autopage(mut self, autopage: bool) -> Self {
+        self.autopage = autopage;
+        self
+    }
+}
+
+
+
+const LIST_VERSIONS_QUERY: &str = include_str!("list_versions_query.graphql");
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesOptions {
+    architecture: UnityReleaseDownloadArchitecture,
+    platform: UnityReleaseDownloadPlatform,
+    skip: usize,
+    limit: usize,
+    stream: UnityReleaseStream,
+}
+
+impl Default for UnityReleaseDownloadGetUnityReleasesOptions {
+    fn default() -> Self {
+        Self {
+            architecture: Default::default(),
+            platform: Default::default(),
+            skip: Default::default(),
+            limit: 100,
+            stream: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesRequestBody {
+    query: String,
+    variables: UnityReleaseDownloadGetUnityReleasesOptions,
+}
+
+impl UnityReleaseDownloadGetUnityReleasesRequestBody {
+    pub fn new(variables: UnityReleaseDownloadGetUnityReleasesOptions) -> Self {
+        Self {
+            query: LIST_VERSIONS_QUERY.to_string(),
+            variables: variables,
+        }
+    }
+}
+
+impl Default for UnityReleaseDownloadGetUnityReleasesRequestBody {
+    fn default() -> Self {
+        Self {
+            query: LIST_VERSIONS_QUERY.to_string(),
+            variables: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesResultBody {
+    data: UnityReleaseDownloadGetUnityReleasesResultBodyData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesResultBodyData {
+    get_unity_releases: UnityReleaseDownloadGetUnityReleasesResultBodyDataGetUnityReleases,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesResultBodyDataGetUnityReleases {
+    edges: Vec<UnityReleaseDownloadGetUnityReleasesResultBodyDataGetUnityReleasesEdge>,
+    page_info: PageInfo,
+    total_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesResultBodyDataGetUnityReleasesEdge {
+    node: UnityReleaseDownloadGetUnityReleasesResultBodyDataGetUnityReleasesEdgeNode,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnityReleaseDownloadGetUnityReleasesResultBodyDataGetUnityReleasesEdgeNode {
+    version: String,
+    short_revision: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfo {
+    has_next_page: bool,
+    has_previous_page: bool,
+}
+
+
+
+#[derive(Debug)]
+struct ListVersionsPageResult {
+    next_page_options: Option<ListVersionsBuilder>,
+    content: Vec<String>,
+}
+
+impl ListVersionsPageResult {
+    pub fn new(
+        content: impl IntoIterator<Item = String>,
+        next_page_options: Option<ListVersionsBuilder>,
+    ) -> Self {
+        Self {
+            next_page_options: next_page_options,
+            content: content.into_iter().collect(),
+        }
+    }
+
+    pub fn has_next_page(&self) -> bool {
+        self.next_page_options.is_some()
+    }
+
+    pub fn next_page(self) -> Option<Result<Self>> {
+        let b = self.next_page_options?;
+        Some(b.send())
+    }
+}
+
+impl IntoIterator for ListVersionsPageResult {
+    type Item = String;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.content.into_iter()
+    }
+}
+
+
+
+impl From<ListVersionsBuilder> for UnityReleaseDownloadGetUnityReleasesOptions {
+    fn from(value: ListVersionsBuilder) -> Self {
+        Self {
+            architecture: value.architecture,
+            platform: value.platform,
+            skip: value.skip,
+            limit: value.limit,
+            stream: value.stream,
+        }
+    }
+}

--- a/uvm_live_platform/src/api/list_versions_query.graphql
+++ b/uvm_live_platform/src/api/list_versions_query.graphql
@@ -1,0 +1,21 @@
+query MyQuery2($architecture: [UnityReleaseDownloadArchitecture!] = ARM64, $platform: [UnityReleaseDownloadPlatform!] = MAC_OS, $limit: Int = 10, $skip: Int = 0, $stream: [UnityReleaseStream!] = LTS) {
+    getUnityReleases(
+        architecture: $architecture
+        platform: $platform
+        skip: $skip
+        limit: $limit
+        stream: $stream
+    ) {
+        edges {
+            node {
+                version
+                shortRevision
+            }
+        }
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+        }
+        totalCount
+    }
+}

--- a/uvm_live_platform/src/api/mod.rs
+++ b/uvm_live_platform/src/api/mod.rs
@@ -1,0 +1,2 @@
+pub mod list_versions;
+

--- a/uvm_live_platform/src/error.rs
+++ b/uvm_live_platform/src/error.rs
@@ -1,0 +1,17 @@
+use std::fmt::Display;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub struct LivePlatformError {
+    pub msg: String,
+    
+    #[source]
+    pub source: anyhow::Error,
+}
+
+impl Display for LivePlatformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LivePlatformError: {}", self.msg)
+    }
+}

--- a/uvm_live_platform/src/lib.rs
+++ b/uvm_live_platform/src/lib.rs
@@ -1,0 +1,25 @@
+pub mod error;
+mod model;
+pub use model::*;
+mod api;
+
+pub use api::list_versions::ListVersions;
+
+pub type Result<T> = std::result::Result<T, error::LivePlatformError>;
+
+pub fn versions() -> Result<impl Iterator<Item = String>> {
+    _list_all_versions(false, false)
+}
+
+pub fn all_versions() -> Result<impl Iterator<Item = String>> {
+    _list_all_versions(false, true)
+}
+
+pub fn all_versions_with_revision() -> Result<impl Iterator<Item = String>> {
+    _list_all_versions(true, true)
+}
+
+fn _list_all_versions(include_revisions: bool, autopage: bool) -> Result<ListVersions> {
+    ListVersions::builder().include_revision(include_revisions).autopage(autopage).list()
+}
+

--- a/uvm_live_platform/src/model.rs
+++ b/uvm_live_platform/src/model.rs
@@ -1,0 +1,57 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum UnityReleaseDownloadArchitecture {
+    X86_64,
+    Arm64
+}
+
+impl Default for UnityReleaseDownloadArchitecture {
+    fn default() -> Self {
+        if cfg!(target_arch = "x86_64") {
+            Self::X86_64
+        } else if cfg!(target_arch = "aarch64") {
+            Self::Arm64
+        } else {
+            panic!("Not supported on current architecture")
+        } 
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum UnityReleaseDownloadPlatform {
+    MacOs,
+    Linux,
+    Windows
+}
+
+impl Default for UnityReleaseDownloadPlatform {
+    fn default() -> Self {
+        if cfg!(target_os = "linux") {
+            Self::Linux
+        } else if cfg!(target_os = "macos") {
+            Self::Windows
+        } else if cfg!(target_os = "macos") {
+            Self::MacOs
+        } else {
+            panic!("Not supported on current OS")
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum UnityReleaseStream {
+    Lts,
+    Beta,
+    Alpha,
+    Tech,
+}
+
+impl Default for UnityReleaseStream {
+    fn default() -> Self {
+        Self::Lts
+    }
+}


### PR DESCRIPTION
## Description

This is a first patch to introduce a new crate to connect to the live platform service. This service is a graphql service which allows a handful of operations around unity releases etc. This service is used directly by UnityHub to query latest releases and to fetch information for older releases. This used to be semi-hardcoded in Unity Hub. The first API allows to query for Unity versions. Others will follow soon.
