### PR TITLE
Add new sub crate unity-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -672,6 +672,17 @@ name = "derive_deref"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcdbcee2d9941369faba772587a565f4f534e42cb8d17e5295871de730163b2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.86",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1017,6 +1028,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1483,9 +1505,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linked-hash-map"
@@ -1596,6 +1624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1717,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,11 +1737,12 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg 1.1.0",
+ "libm",
 ]
 
 [[package]]
@@ -1915,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1936,10 +1981,30 @@ dependencies = [
  "quick-error",
  "rand 0.6.5",
  "rand_chacha 0.1.1",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "regex-syntax 0.6.26",
- "rusty-fork",
+ "rusty-fork 0.2.2",
  "tempfile",
+]
+
+[[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.0",
+ "lazy_static 1.4.0",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax 0.8.2",
+ "rusty-fork 0.3.0",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1959,10 +2024,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quote"
-version = "1.0.33"
+name = "quickcheck"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log 0.4.20",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1995,7 +2071,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi 0.3.9",
 ]
 
@@ -2005,11 +2081,22 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2033,6 +2120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,7 +2150,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -2125,6 +2231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2223,6 +2338,12 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "remove_dir_all"
@@ -2351,6 +2472,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "semver-parser"
@@ -2436,22 +2569,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2630,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2705,22 +2838,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2989,7 +3122,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3003,6 +3136,12 @@ name = "ucd-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -3051,6 +3190,19 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unity-version"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "nom",
+ "proptest 1.4.0",
+ "quickcheck",
+ "semver 1.0.22",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3318,7 +3470,7 @@ dependencies = [
  "console 0.6.2",
  "indicatif 0.9.0",
  "log 0.4.20",
- "semver 1.0.6",
+ "semver 1.0.22",
  "structopt",
  "uvm_cli",
  "uvm_core",
@@ -3374,11 +3526,11 @@ dependencies = [
  "log 0.4.20",
  "md-5",
  "plist 0.3.0",
- "proptest",
+ "proptest 0.9.6",
  "rand 0.7.3",
  "regex 1.5.6",
  "reqwest 0.9.24",
- "semver 1.0.6",
+ "semver 1.0.22",
  "serde",
  "serde_derive",
  "serde_ini",
@@ -3538,7 +3690,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
@@ -3572,7 +3724,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "1"
 members = [
   "uvm_core",
   "uvm_cli",
@@ -8,4 +8,4 @@ members = [
   "uvm_move_dir",
   "commands/*",
   "install/*"
-]
+, "unity-version"]

--- a/unity-version/Cargo.toml
+++ b/unity-version/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "unity-version"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut", "as_ref", "as_mut", "display"] }
+nom = "7.1.3"
+semver = "1.0.22"
+serde = { version = "1.0.197", features = ["derive"] }
+thiserror = "1.0.57"
+
+[dev-dependencies]
+proptest = "1.4.0"
+quickcheck = "1.0.3"

--- a/unity-version/proptest-regressions/version/mod.txt
+++ b/unity-version/proptest-regressions/version/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc da6c38f66a9854bc766759a3e02b8fd53c14111d713e836ebe5375a8e1c1bda1 # shrinks to s = "0.0.0a20000000000000000000"

--- a/unity-version/proptest-regressions/version/release_type.txt
+++ b/unity-version/proptest-regressions/version/release_type.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 14d49815deb3a87ab8c16b04563519beb30569ae6f03e422e0beac7e3bdfadf3 # shrinks to s = "alpha"

--- a/unity-version/src/lib.rs
+++ b/unity-version/src/lib.rs
@@ -1,0 +1,5 @@
+mod version;
+pub use version::Version;
+pub use version::ReleaseType;
+
+

--- a/unity-version/src/version/mod.rs
+++ b/unity-version/src/version/mod.rs
@@ -1,0 +1,219 @@
+use derive_more::Display;
+use std::{cmp::Ordering, str::FromStr};
+
+use nom::{
+    branch::alt,
+    character::complete::{char, digit1},
+    combinator::map_res,
+    error::{context, convert_error, VerboseError},
+    sequence::tuple,
+    IResult,
+};
+
+mod release_type;
+mod revision_hash;
+pub use release_type::ReleaseType;
+pub use revision_hash::RevisionHash;
+
+#[derive(Eq, Debug, Clone, Hash, PartialOrd, Display)]
+#[display(fmt = "{}{}{}", base, release_type, revision)]
+pub struct Version {
+    base: semver::Version,
+    release_type: ReleaseType,
+    revision: u64,
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Version) -> Ordering {
+        self.base
+            .cmp(&other.base)
+            .then(self.release_type.cmp(&other.release_type))
+            .then(self.revision.cmp(&other.revision))
+    }
+}
+
+impl PartialEq for Version {
+    fn eq(&self, other: &Self) -> bool {
+        self.base == other.base
+            && self.release_type == other.release_type
+            && self.revision == other.revision
+    }
+}
+
+impl AsRef<Version> for Version {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl AsMut<Version> for Version {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl FromStr for Version {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match parse_version(s) {
+            Ok((_, version)) => Ok(version),
+            Err(err) => {
+                let verbose_error = match err {
+                    nom::Err::Error(e) | nom::Err::Failure(e) => e,
+                    _ => VerboseError {
+                        errors: vec![(s, nom::error::VerboseErrorKind::Context("unknown error"))],
+                    },
+                };
+                Err(convert_error(s, verbose_error))
+            }
+        }
+    }
+}
+
+impl Version {
+    pub fn new(
+        major: u64,
+        minor: u64,
+        patch: u64,
+        release_type: ReleaseType,
+        revision: u64,
+    ) -> Version {
+        let base = semver::Version::new(major, minor, patch);
+        Version {
+            base,
+            release_type,
+            revision,
+        }
+    }
+
+    pub fn release_type(&self) -> ReleaseType {
+        self.release_type
+    }
+
+    pub fn major(&self) -> u64 {
+        self.base.major
+    }
+
+    pub fn minor(&self) -> u64 {
+        self.base.minor
+    }
+
+    pub fn patch(&self) -> u64 {
+        self.base.patch
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+}
+
+#[derive(Eq, Debug, Clone, Hash, Display)]
+#[display(fmt = "{} ({})", version, revision)]
+pub struct CompleteVersion{
+    version: Version, 
+    revision: RevisionHash
+}
+
+
+impl PartialEq for CompleteVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version
+    }
+}
+
+impl PartialOrd for CompleteVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.version.partial_cmp(&other.version) 
+    }
+}
+
+
+fn parse_release_type(input: &str) -> IResult<&str, ReleaseType, VerboseError<&str>> {
+    context(
+        "release type",
+        map_res(alt((char('f'), char('b'), char('a'), char('p'))), |c| {
+            ReleaseType::try_from(c)
+        }),
+    )(input)
+}
+
+fn parse_version(input: &str) -> IResult<&str, Version, VerboseError<&str>> {
+    context(
+        "version",
+        tuple((
+            context("major version", map_res(digit1, |s: &str| s.parse::<u64>())),
+            char('.'),
+            context("minor version", map_res(digit1, |s: &str| s.parse::<u64>())),
+            char('.'),
+            context("patch version", map_res(digit1, |s: &str| s.parse::<u64>())),
+            context("release type", parse_release_type),
+            context("revision", map_res(digit1, |s: &str| s.parse::<u64>())),
+        )),
+    )(input)
+    .map(
+        |(next_input, (major, _, minor, _, patch, release_type, revision))| {
+            let base = semver::Version::new(major, minor, patch);
+            (
+                next_input,
+                Version {
+                    base,
+                    release_type,
+                    revision,
+                },
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn parse_version_string_with_valid_input() {
+        let version_string = "1.2.3f4";
+        let version = Version::from_str(version_string);
+        assert!(version.is_ok(), "valid input returns a version")
+    }
+
+    #[test]
+    fn splits_version_string_into_components() {
+        let version_string = "11.2.3f4";
+        let version = Version::from_str(version_string).unwrap();
+
+        assert!(version.base.major == 11, "parse correct major component");
+        assert!(version.base.minor == 2, "parse correct minor component");
+        assert!(version.base.patch == 3, "parse correct patch component");
+
+        assert_eq!(version.release_type, ReleaseType::Final);
+        assert!(version.revision == 4, "parse correct revision component");
+    }
+
+    proptest! {
+        #[test]
+        fn from_str_does_not_crash(s in "\\PC*") {
+            let _v = Version::from_str(&s);
+        }
+
+        #[test]
+        fn from_str_supports_all_valid_cases(
+            major in 0u64..=u64::MAX,
+            minor in 0u64..=u64::MAX,
+            patch in 0u64..=u64::MAX,
+            release_type in prop_oneof!["f", "p", "b", "a"],
+            revision in 0u64..=u64::MAX,
+        ) {
+            let version_string = format!("{}.{}.{}{}{}", major, minor, patch, release_type, revision);
+            let version = Version::from_str(&version_string).unwrap();
+
+            assert!(version.base.major == major, "parse correct major component");
+            assert!(version.base.minor == minor, "parse correct minor component");
+            assert!(version.base.patch == patch, "parse correct patch component");
+
+            assert_eq!(version.release_type, ReleaseType::from_str(&release_type).unwrap());
+            assert!(version.revision == revision, "parse correct revision component");
+        }
+    }
+}

--- a/unity-version/src/version/release_type.rs
+++ b/unity-version/src/version/release_type.rs
@@ -1,0 +1,140 @@
+use serde::Deserialize;
+use std::{cmp::Ordering, fmt, str::FromStr};
+use thiserror::Error;
+
+#[derive(PartialEq, Eq, Ord, Hash, Debug, Clone, Copy, Deserialize)]
+pub enum ReleaseType {
+    Alpha,
+    Beta,
+    Patch,
+    Final,
+}
+
+impl PartialOrd for ReleaseType {
+    fn partial_cmp(&self, other: &ReleaseType) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for ReleaseType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            match *self {
+                ReleaseType::Final => write!(f, "final"),
+                ReleaseType::Patch => write!(f, "patch"),
+                ReleaseType::Beta => write!(f, "beta"),
+                ReleaseType::Alpha => write!(f, "alpha"),
+            }
+        } else {
+            match *self {
+                ReleaseType::Final => write!(f, "f"),
+                ReleaseType::Patch => write!(f, "p"),
+                ReleaseType::Beta => write!(f, "b"),
+                ReleaseType::Alpha => write!(f, "a"),
+            }
+        }
+    }
+}
+
+impl Default for ReleaseType {
+    fn default() -> ReleaseType {
+        ReleaseType::Final
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ReleaseTypeError {
+    #[error("Unknown release type: {0}")]
+    UnknownType(String),
+
+    #[error("Invalid release type character: {0}")]
+    InvalidCharacter(char),
+}
+
+impl FromStr for ReleaseType {
+    type Err = ReleaseTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "a" => Ok(ReleaseType::Alpha),
+            "b" => Ok(ReleaseType::Beta),
+            "p" => Ok(ReleaseType::Patch),
+            "f" => Ok(ReleaseType::Final),
+            _ => Err(ReleaseTypeError::UnknownType(s.to_string())),
+        }
+    }
+}
+
+impl TryFrom<char> for ReleaseType {
+    type Error = ReleaseTypeError;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value {
+            'f' => Ok(ReleaseType::Final),
+            'b' => Ok(ReleaseType::Beta),
+            'a' => Ok(ReleaseType::Alpha),
+            'p' => Ok(ReleaseType::Patch),
+            _ => Err(ReleaseTypeError::InvalidCharacter(value)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use proptest::prelude::*;
+
+    #[test]
+    fn should_return_final_when_given_f_as_input() {
+        let result = ReleaseType::try_from('f');
+        assert_eq!(result, Ok(ReleaseType::Final));
+    }
+    #[test]
+    fn should_return_alpha_when_given_a_as_input() {
+        let result = ReleaseType::try_from('a');
+        assert_eq!(result, Ok(ReleaseType::Alpha));
+    }
+    #[test]
+    fn should_return_beta_when_given_b_as_input() {
+        let result = ReleaseType::try_from('b');
+        assert_eq!(result, Ok(ReleaseType::Beta));
+    }
+    #[test]
+    fn should_return_patch_when_given_p_as_input() {
+        let result = ReleaseType::try_from('p');
+        assert_eq!(result, Ok(ReleaseType::Patch));
+    }
+    #[test]
+    fn should_return_error_when_given_empty_input() {
+        let result = ReleaseType::try_from(' ');
+        assert_eq!(result, Err(ReleaseTypeError::InvalidCharacter(' ')));
+    }
+
+    #[test]
+    fn should_return_correct_to_string_value() {
+        assert_eq!(ReleaseType::Final.to_string(), "f");
+        assert_eq!(ReleaseType::Patch.to_string(), "p");
+        assert_eq!(ReleaseType::Alpha.to_string(), "a");
+        assert_eq!(ReleaseType::Beta.to_string(), "b");
+    }
+    #[test]
+    fn should_format_using_correct_alternative_format() {
+        assert_eq!(&format!("{:#}", ReleaseType::Final), "final");
+        assert_eq!(&format!("{:#}", ReleaseType::Patch), "patch");
+        assert_eq!(&format!("{:#}", ReleaseType::Beta), "beta");
+        assert_eq!(&format!("{:#}", ReleaseType::Alpha), "alpha");
+    }
+
+    proptest! {
+        #[test]
+        fn from_str_does_not_crash(s in "\\PC*") {
+            let _r = ReleaseType::from_str(&s);
+        }
+
+        #[test]
+        fn from_str_supports_all_valid_cases(s in "(a|b|f|p)") {
+            ReleaseType::from_str(&s).unwrap();
+        }
+    }
+}

--- a/unity-version/src/version/revision_hash.rs
+++ b/unity-version/src/version/revision_hash.rs
@@ -1,0 +1,48 @@
+use thiserror::Error;
+use derive_more::{Deref, Display};
+use std::str::FromStr;
+
+#[derive(Debug, Error)]
+pub enum RevisionHashError {
+    #[error("Input must be exactly 12 characters long")]
+    InvalidLength,
+
+    #[error("Input contains invalid characters")]
+    InvalidCharacter,
+}
+
+#[derive(Eq, Debug, Clone, Hash, Display, Deref)]
+#[display(fmd = "{}", 0)]
+pub struct RevisionHash(String);
+
+impl RevisionHash {
+    pub fn new(input: &str) -> Result<Self, RevisionHashError> {
+        if input.len() != 12 {
+            return Err(RevisionHashError::InvalidLength);
+        }
+
+        if input.chars().all(|c| c.is_ascii_hexdigit()) {
+            Ok(RevisionHash(input.to_string()))
+        } else {
+            return Err(RevisionHashError::InvalidCharacter);
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq for RevisionHash {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl FromStr for RevisionHash {
+    type Err = RevisionHashError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+       RevisionHash::new(s) 
+    }
+}


### PR DESCRIPTION
## Description

This is a new implementation of the Unity version struct and parsing methods to represent a Unity version inside uvm. It will be used with future patches. The old representation tried to combine a normal unity version with an optional revision hash. I constructed this as a seperate type. Conversion methods are not yet available because I need to see how I will actually use both types.