### PR TITLE
Improve error reporting for missing commands

### DIFF
--- a/install/uvm_install_core/src/lib.rs
+++ b/install/uvm_install_core/src/lib.rs
@@ -59,3 +59,10 @@ pub trait InstallHandler {
         Ok(())
     }
 }
+
+pub fn handle_notfound(program: &str, e: std::io::Error) -> Error {
+    if let std::io::ErrorKind::NotFound = e.kind() {
+        error!("Error: '{0}' command not found.\nuvm requires '{0}' to install modules. Please ensure '{0}' is installed and accessible in your PATH.", program);
+    }
+    e.into()
+}

--- a/install/uvm_install_core/src/sys/linux/pkg.rs
+++ b/install/uvm_install_core/src/sys/linux/pkg.rs
@@ -30,7 +30,8 @@ impl ModulePkgInstaller {
             .arg(installer)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .spawn()?;
+            .spawn()
+            .map_err(|e| handle_notfound("7z", e))?;
 
         let output = child.wait_with_output()?;
         if !output.status.success() {
@@ -59,7 +60,8 @@ impl ModulePkgInstaller {
                 .arg("-iu")
                 .current_dir(destination)
                 .stdin(Stdio::piped())
-                .spawn()?;
+                .spawn()
+                .map_err(|e| handle_notfound("cpio", e))?;
             {
                 let stdin = cpio.stdin.as_mut().ok_or("Failed to open cpio stdin")?;
                 let mut file = File::open(payload)?;
@@ -72,13 +74,15 @@ impl ModulePkgInstaller {
                 .arg("-dc")
                 .arg(payload)
                 .stdout(Stdio::piped())
-                .spawn()?;
+                .spawn()
+                .map_err(|e| handle_notfound("gzip", e))?;
 
             let mut cpio = Command::new("cpio")
                 .arg("-iu")
                 .current_dir(destination)
                 .stdin(Stdio::piped())
-                .spawn()?;
+                .spawn()
+                .map_err(|e| handle_notfound("cpio", e))?;
             {
                 let gzip_stdout = gzip.stdout.as_mut().ok_or("Failed to open gzip stdout")?;
                 let cpio_stdin = cpio.stdin.as_mut().ok_or("Failed to open cpio stdin")?;

--- a/install/uvm_install_core/src/sys/linux/xz.rs
+++ b/install/uvm_install_core/src/sys/linux/xz.rs
@@ -26,7 +26,8 @@ impl<V, I> Installer<V, Xz, I> {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .spawn()?;
+            .spawn()
+            .map_err(|e| handle_notfound("tar", e))?;
 
         let tar_output = tar_child.wait_with_output()?;
         if !tar_output.status.success() {


### PR DESCRIPTION
Previously, installation failures would only display a generic 'Failure during installation' message, making troubleshooting difficult, especially for common issues like missing command-line tools.

This update adds explicit error messages when required commands are not found, simplifying user troubleshooting.