### PR TITLE
Fix module deserialize issue when module.json was written by older uvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "uvm_live_platform"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "derive-getters",

--- a/uvm_live_platform/Cargo.toml
+++ b/uvm_live_platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm_live_platform"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 description = "Methods to connect to the unity live platform service."
 repository = "https://github.com/Larusso/unity-version-manager"

--- a/uvm_live_platform/src/model/release.rs
+++ b/uvm_live_platform/src/model/release.rs
@@ -52,7 +52,7 @@ impl Download {
 pub struct Module {
     #[serde(rename = "__typename")]
     #[getter(skip)]
-    type_name: String,
+    type_name: Option<String>,
     #[serde(flatten)]
     release_file: UnityReleaseFile,
     id: String,


### PR DESCRIPTION
## Description

I added `__typename` to the module.json definition. Now its required to be part of the modules.json. That may not be the case when the file got written by an older Unity Hub version or UVM.