### PR TITLE
Fix cache dir location

### DIFF
--- a/commands/uvm/tests/cli_detect.rs
+++ b/commands/uvm/tests/cli_detect.rs
@@ -4,6 +4,7 @@ use tempfile::tempdir;
 
 
 #[test]
+#[cfg(unix)]
 fn test_uvm_detect_help() {
     let output = Command::new(env!("CARGO_BIN_EXE_uvm"))
         .arg("detect")

--- a/install/uvm-install2/src/main.rs
+++ b/install/uvm-install2/src/main.rs
@@ -13,14 +13,14 @@ struct Cli {
     ///
     /// A support module to install. You can list all available
     /// modules for a given version using `uvm-modules`
-    #[arg(short, long = "module", number_of_values = 1, group = "module")]
+    #[arg(short, long = "module", number_of_values = 1)]
     modules: Option<Vec<String>>,
 
     /// Install also synced modules
     ///
     /// Synced modules are optional dependencies of some Unity modules.
     /// e.g. Android SDK for the android module.
-    #[arg(long = "with-sync", group = "module")]
+    #[arg(long = "with-sync")]
     sync: bool,
 
     /// The api version to install in the form of `2018.1.0f3`

--- a/unity-hub/src/unity/hub/paths.rs
+++ b/unity-hub/src/unity/hub/paths.rs
@@ -44,7 +44,7 @@ pub fn default_editor_config_path() -> Option<PathBuf> {
 }
 
 pub fn cache_dir() -> Option<PathBuf> {
-    dirs_2::cache_dir().map(|path| path.join("com.github.larusso.api-version-manager"))
+    dirs_2::cache_dir().map(|path| path.join("com.github.larusso.unity-version-manager"))
 }
 
 pub fn locks_dir() -> Option<PathBuf> {


### PR DESCRIPTION
## Description

Due to some reason the cache location was changed with the recent update. This can and will lead to issues with older versions of uvm since the lock file location is inside the cache dir.

A simple change to restore the old location.