### PR TITLE
Fix locking logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "uvm-install2"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm-install2"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 description = "Install specified unity version."
 repository = "https://github.com/Larusso/unity-version-manager"

--- a/install/uvm-install2/src/lib.rs
+++ b/install/uvm-install2/src/lib.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
+use std::fs::File;
 use sys::create_installer;
 pub use unity_hub::error::UnityError;
 pub use unity_hub::error::UnityHubError;


### PR DESCRIPTION
## Description

The locking logic had a slight bug as it treats all types of errors equally. But we only need to check for already locked type of an error. I think in praxis this would have not come up since the next call to wait_lock would failed as well. But the intention is cleaner.