### PR TITLE
Fix removing destination before install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "uvm-install2"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm-install2"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 description = "Install specified unity version."
 repository = "https://github.com/Larusso/unity-version-manager"

--- a/install/uvm-install2/src/install/installer/zip.rs
+++ b/install/uvm-install2/src/install/installer/zip.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use crate::install::error::InstallerResult;
+use crate::install::error::{InstallerError, InstallerResult};
 use crate::install::installer::{Installer, InstallerWithDestination};
 use crate::install::{InstallHandler, UnityModule};
 use crate::*;
@@ -114,6 +114,19 @@ impl InstallHandler for ModuleZipInstaller {
         );
 
         self.deploy_zip_with_rename(installer, destination, rename_handler)
+    }
+
+    fn before_install(&self) -> std::result::Result<(), InstallerError> {
+        if self.destination().exists() {
+            if self.destination().is_dir() {
+                info!("Destination directory {} already exists, removing it", self.destination().display());
+                fs::remove_dir_all(self.destination()).context("failed to remove the existing destination directory")?;
+            } else {
+                info!("Destination file {} already exists, removing it", self.destination().display());
+                fs::remove_file(self.destination()).context("failed to remove the existing destination file")?;
+            }
+        }
+        Ok(())
     }
 
     fn error_handler(&self) {

--- a/install/uvm-install2/src/sys/linux/zip.rs
+++ b/install/uvm-install2/src/sys/linux/zip.rs
@@ -1,8 +1,10 @@
+use std::fs;
 use std::path::Path;
 use crate::*;
 use crate::install::installer::{Installer, InstallerWithDestination, Zip};
 use crate::install::{InstallHandler, UnityEditor};
 use crate::install::error::InstallerResult;
+use thiserror_context::Context;
 
 pub type EditorZipInstaller = Installer<UnityEditor, Zip, InstallerWithDestination>;
 

--- a/install/uvm-install2/src/sys/mac/pkg.rs
+++ b/install/uvm-install2/src/sys/mac/pkg.rs
@@ -2,7 +2,7 @@ use crate::install::error::InstallerErrorInner::{InstallationFailed, InstallerCr
 use crate::install::error::{InstallerError, InstallerResult};
 use crate::install::installer::{BaseInstaller, Installer, InstallerWithDestination, Pkg};
 use crate::install::{InstallHandler, UnityEditor, UnityModule};
-use log::{debug, warn};
+use log::{debug, info, warn};
 use std::fs::DirBuilder;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -188,6 +188,19 @@ impl InstallHandler for EditorPkgInstaller {
     fn installer(&self) -> &Path {
         self.installer()
     }
+
+    fn before_install(&self) -> InstallerResult<()> {
+        if self.destination().exists() {
+            if self.destination().is_dir() {
+                info!("Destination directory {} already exists, removing it", self.destination().display());
+                fs::remove_dir_all(self.destination()).context("failed to remove the existing destination directory")?;
+            } else {
+                info!("Destination file {} already exists, removing it", self.destination().display());
+                fs::remove_file(self.destination()).context("failed to remove the existing destination file")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl InstallHandler for ModulePkgInstaller {
@@ -223,6 +236,19 @@ impl InstallHandler for ModulePkgInstaller {
 
     fn installer(&self) -> &Path {
         self.installer()
+    }
+
+    fn before_install(&self) -> InstallerResult<()> {
+        if self.destination().exists() {
+            if self.destination().is_dir() {
+                info!("Destination directory {} already exists, removing it", self.destination().display());
+                fs::remove_dir_all(self.destination()).context("failed to remove the existing destination directory")?;
+            } else {
+                info!("Destination file {} already exists, removing it", self.destination().display());
+                fs::remove_file(self.destination()).context("failed to remove the existing destination file")?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/install/uvm-install2/src/sys/win/msi.rs
+++ b/install/uvm-install2/src/sys/win/msi.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use crate::error::*;
 use crate::*;
 use std::io::Write;


### PR DESCRIPTION
## Description

There is a failing case when the installer things it should install a missing component even though the output path exists. In older versions this was used as a install marker.

We need to remove the destination now and reinstall cleanly.