### PR TITLE
Add support to list and query XLTS releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "uvm_live_platform"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "derive-getters",

--- a/commands/uvm-generate-versions-yaml/src/main.rs
+++ b/commands/uvm-generate-versions-yaml/src/main.rs
@@ -20,16 +20,19 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         UnityReleaseStream::Beta,
         UnityReleaseStream::Lts,
         UnityReleaseStream::Tech,
+        UnityReleaseStream::Supported
     ];
 
     let versions = streams
         .par_iter()
         .map(|stream| {
             ListVersions::builder()
-                .architecture(UnityReleaseDownloadArchitecture::X86_64)
+                .with_architecture(UnityReleaseDownloadArchitecture::X86_64)
                 .autopage(true)
+                .with_extended_lts()
+                .with_u7_alpha()
                 .include_revision(true)
-                .stream(stream.to_owned())
+                .with_stream(stream.to_owned())
                 .list()
         })
         .filter_map(|v| v.ok())

--- a/install/uvm-install2/Cargo.toml
+++ b/install/uvm-install2/Cargo.toml
@@ -26,7 +26,7 @@ serde_derive = "1.0"
 thiserror = "2.0.11"
 clap = {  version = "4.5.29", features = ["derive", "string", "env", "cargo"] }
 unity-version = { path = "../../unity-version", version = "0.1.0"}
-uvm_live_platform = { path = "../../uvm_live_platform", version = "0.3.0"}
+uvm_live_platform = { path = "../../uvm_live_platform", version = "0.4.0"}
 uvm_install_graph = { path = "../../uvm_install_graph", version = "0.10.0"}
 unity-hub = {path = "../../unity-hub", version = "0.3.0" }
 #uvm_install_core = {path = "../uvm_install_core" }

--- a/unity-hub/Cargo.toml
+++ b/unity-hub/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 unity-version = {path = "../unity-version", version = "0.1.0" }
 unity-types = {path = "../unity-types", version = "0.1.0"}
-uvm_live_platform = { path = "../uvm_live_platform",  version = "0.3.0" }
+uvm_live_platform = { path = "../uvm_live_platform",  version = "0.4.0" }
 log = "0.4.26"
 serde_json = "1.0.139"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/uvm_install_graph/Cargo.toml
+++ b/uvm_install_graph/Cargo.toml
@@ -20,7 +20,7 @@ daggy = "0.8.1"
 fixedbitset = "0.5.7"
 itertools = "0.14.0"
 #uvm_core = { path = "../uvm_core", version = "0.13.3" }
-uvm_live_platform = { path = "../uvm_live_platform", version = "0.3.0" }
+uvm_live_platform = { path = "../uvm_live_platform", version = "0.4.0" }
 unity-version = {path = "../unity-version", version = "0.1.0" }
 [dev-dependencies]
 cfg-if = "1.0.0"

--- a/uvm_live_platform/Cargo.toml
+++ b/uvm_live_platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvm_live_platform"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 description = "Methods to connect to the unity live platform service."
 repository = "https://github.com/Larusso/unity-version-manager"

--- a/uvm_live_platform/src/api/fetch_release_query.graphql
+++ b/uvm_live_platform/src/api/fetch_release_query.graphql
@@ -3,6 +3,7 @@ query FetchReleaseQuery(
   $platform: [UnityReleaseDownloadPlatform!]
   $stream: [UnityReleaseStream!]
   $version: String
+  $entitlements: [UnityReleaseEntitlement!]
 ) {
   getUnityReleases(
     architecture: $architecture
@@ -11,6 +12,7 @@ query FetchReleaseQuery(
     limit: 1
     stream: $stream
     version: $version
+    entitlements: $entitlements
   ) {
     edges {
       node {

--- a/uvm_live_platform/src/api/list_versions_query.graphql
+++ b/uvm_live_platform/src/api/list_versions_query.graphql
@@ -1,10 +1,20 @@
-query ListVersionsQuery($architecture: [UnityReleaseDownloadArchitecture!], $platform: [UnityReleaseDownloadPlatform!], $limit: Int = 10, $skip: Int = 0, $stream: [UnityReleaseStream!]) {
+query ListVersionsQuery(
+    $architecture: [UnityReleaseDownloadArchitecture!]
+    $platform: [UnityReleaseDownloadPlatform!]
+    $limit: Int = 10
+    $skip: Int = 0
+    $stream: [UnityReleaseStream!]
+    $entitlements: [UnityReleaseEntitlement!]
+    $version: String
+) {
     getUnityReleases(
         architecture: $architecture
         platform: $platform
         skip: $skip
         limit: $limit
         stream: $stream
+        entitlements: $entitlements
+        version: $version
     ) {
         edges {
             node {

--- a/uvm_live_platform/src/error.rs
+++ b/uvm_live_platform/src/error.rs
@@ -43,8 +43,8 @@ pub enum FetchReleaseError {
     #[error("Invalid JSON response")]
     JsonError(#[source] reqwest::Error),
 
-    #[error("Release not found for version: {0} platform: {1} architecture: {2} stream: {3:?}")]
-    NotFound(String, UnityReleaseDownloadPlatform, UnityReleaseDownloadArchitecture, Option<UnityReleaseStream>),
+    #[error("Release not found for version: {0} platform: {1} architecture: {2} stream: {3}")]
+    NotFound(String, String, String, String),
 
     #[error("Network error: {0}")]
     NetworkError(#[source] reqwest::Error),

--- a/uvm_live_platform/src/lib.rs
+++ b/uvm_live_platform/src/lib.rs
@@ -25,6 +25,10 @@ pub fn all_versions_with_revision() -> Result<impl Iterator<Item = String>> {
 fn _list_all_versions(include_revisions: bool, auto_page: bool) -> Result<ListVersions> {
     Ok(ListVersions::builder()
         .include_revision(include_revisions)
+        .with_u7_alpha()
+        .with_extended_lts()
+        .with_system_architecture()
+        .with_current_platform()
         .autopage(auto_page)
         .list()
         .map_err(ErrorRepr::ListVersionsError)?)
@@ -32,6 +36,10 @@ fn _list_all_versions(include_revisions: bool, auto_page: bool) -> Result<ListVe
 
 pub fn fetch_release<V: Into<Version>>(version: V) -> Result<Release> {
     let r = FetchRelease::builder(version)
+        .with_current_platform()
+        .with_system_architecture()
+        .with_extended_lts()
+        .with_u7_alpha()
         .fetch()
         .map_err(ErrorRepr::FetchReleaseError)?;
     Ok(r)

--- a/uvm_live_platform/tests/fetch_release_integration.rs
+++ b/uvm_live_platform/tests/fetch_release_integration.rs
@@ -5,9 +5,9 @@ use crate::{UnityReleaseDownloadArchitecture, UnityReleaseDownloadPlatform, Unit
 fn test_fetch_release_basic() {
     let version = "2022.3.33f1"; // Use a real Unity version
     let result = FetchRelease::try_builder(version).unwrap()
-        .platform(UnityReleaseDownloadPlatform::MacOs)
-        .architecture(UnityReleaseDownloadArchitecture::Arm64)
-        .stream(UnityReleaseStream::Lts)
+        .with_platform(UnityReleaseDownloadPlatform::MacOs)
+        .with_architecture(UnityReleaseDownloadArchitecture::Arm64)
+        .with_stream(UnityReleaseStream::Lts)
         .fetch();
 
     assert!(result.is_ok(), "Fetching release failed");
@@ -21,9 +21,9 @@ fn test_fetch_release_basic() {
 fn test_fetch_release_invalid_version() {
     let version = "9999.9.9f9".to_string(); // Nonexistent version
     let result = FetchRelease::try_builder(version).unwrap()
-        .platform(UnityReleaseDownloadPlatform::Linux)
-        .architecture(UnityReleaseDownloadArchitecture::X86_64)
-        .stream(UnityReleaseStream::Lts)
+        .with_platform(UnityReleaseDownloadPlatform::Linux)
+        .with_architecture(UnityReleaseDownloadArchitecture::X86_64)
+        .with_stream(UnityReleaseStream::Lts)
         .fetch();
 
     assert!(result.is_err(), "Expected error for invalid Unity version, but got success");
@@ -42,9 +42,32 @@ fn test_fetch_release_different_platforms() {
 
     for platform in platforms {
         let result = FetchRelease::try_builder(version.clone()).unwrap()
-            .platform(platform)
-            .architecture(UnityReleaseDownloadArchitecture::X86_64)
-            .stream(UnityReleaseStream::Lts)
+            .with_platform(platform)
+            .with_architecture(UnityReleaseDownloadArchitecture::X86_64)
+            .with_stream(UnityReleaseStream::Lts)
+            .fetch();
+
+        assert!(result.is_ok(), "Failed to fetch release for platform {:?} error: {:?}", platform, result.unwrap_err());
+        println!("Fetched release for {:?}: {:?}", platform, result.unwrap());
+    }
+}
+
+#[test]
+fn test_fetch_extended_lts_release() {
+    let version = "2021.3.48f1".to_string(); // Use a stable version
+
+    let platforms = vec![
+        UnityReleaseDownloadPlatform::MacOs,
+        UnityReleaseDownloadPlatform::Windows,
+        UnityReleaseDownloadPlatform::Linux,
+    ];
+
+    for platform in platforms {
+        let result = FetchRelease::try_builder(version.clone()).unwrap()
+            .with_platform(platform)
+            .with_system_architecture()
+            .with_extended_lts()
+            .with_stream(UnityReleaseStream::Lts)
             .fetch();
 
         assert!(result.is_ok(), "Failed to fetch release for platform {:?} error: {:?}", platform, result.unwrap_err());

--- a/uvm_live_platform/tests/list_version_integration.rs
+++ b/uvm_live_platform/tests/list_version_integration.rs
@@ -5,9 +5,9 @@ use crate::{UnityReleaseDownloadArchitecture, UnityReleaseDownloadPlatform, Unit
 #[test]
 fn test_list_versions_basic() {
     let result = ListVersions::builder()
-        .platform(UnityReleaseDownloadPlatform::Linux)
-        .architecture(UnityReleaseDownloadArchitecture::X86_64)
-        .stream(UnityReleaseStream::Lts)
+        .with_platform(UnityReleaseDownloadPlatform::Linux)
+        .with_architecture(UnityReleaseDownloadArchitecture::X86_64)
+        .with_stream(UnityReleaseStream::Lts)
         .limit(10)
         .list();
 
@@ -23,9 +23,9 @@ fn test_list_versions_basic() {
 #[test]
 fn test_list_versions_pagination() {
     let result = ListVersions::builder()
-        .platform(UnityReleaseDownloadPlatform::Windows)
-        .architecture(UnityReleaseDownloadArchitecture::X86_64)
-        .stream(UnityReleaseStream::Lts)
+        .with_platform(UnityReleaseDownloadPlatform::Windows)
+        .with_architecture(UnityReleaseDownloadArchitecture::X86_64)
+        .with_stream(UnityReleaseStream::Lts)
         .limit(5)
         .autopage(true)
         .list();
@@ -42,9 +42,9 @@ fn test_list_versions_pagination() {
 #[test]
 fn test_list_versions_with_revision() {
     let result = ListVersions::builder()
-        .platform(UnityReleaseDownloadPlatform::MacOs)
-        .architecture(UnityReleaseDownloadArchitecture::Arm64)
-        .stream(UnityReleaseStream::Beta)
+        .with_platform(UnityReleaseDownloadPlatform::MacOs)
+        .with_architecture(UnityReleaseDownloadArchitecture::Arm64)
+        .with_stream(UnityReleaseStream::Beta)
         .limit(3)
         .include_revision(true)
         .list();
@@ -59,5 +59,24 @@ fn test_list_versions_with_revision() {
         versions_vec.iter().all(|v| v.contains('(') && v.contains(')')),
         "Versions do not contain revision hashes"
     );
+    println!("Fetched versions with revision: {:?}", versions_vec);
+}
+
+#[test]
+fn test_list_extended_lts_versions() {
+    let result = ListVersions::builder()
+        .for_current_system()
+        .with_extended_lts()
+        .with_version("2021.3.48")
+        .limit(1)
+        .include_revision(false)
+        .list();
+
+    assert!(result.is_ok(), "Fetching versions with revision failed");
+
+    let versions = result.unwrap();
+    let versions_vec: Vec<String> = versions.collect();
+
+    assert!(!versions_vec.is_empty(), "No versions returned");
     println!("Fetched versions with revision: {:?}", versions_vec);
 }


### PR DESCRIPTION
## Description

Unity has a new LTS version scheme called XLTS which means extended LTS for enterprise customer. By default these can't be listed with the graphql endpoints. One needs to provide an entitlements list to include this versions in the query. The documentation describes them as a filter but it acts more like an inclusion boolean. I also added the second valid entitlement U7_Alpha.

I also changed the builder pattern and usage so the default is more a default and not opinionated.