### PR TITLE
Improve Version command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.1",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1563,12 @@ dependencies = [
  "serde",
  "time",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -2694,6 +2713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "unity-hub"
 version = "0.4.1"
 dependencies = [
@@ -2749,6 +2774,7 @@ dependencies = [
  "clap",
  "console",
  "flexi_logger",
+ "indicatif",
  "itertools",
  "log",
  "semver",

--- a/uvm/Cargo.toml
+++ b/uvm/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = { workspace = true }
 clap = {  version = "4.5.38", features = ["derive", "string", "env", "cargo"] }
 unity-version = { version = "0.2.0", path="../unity-version", features = ["clap"]}
 console = { workspace = true }
+indicatif = "0.18.0"
 flexi_logger = "0.31.2"
 log = { workspace = true }
 semver = { workspace = true }

--- a/uvm/src/commands/version.rs
+++ b/uvm/src/commands/version.rs
@@ -1,11 +1,16 @@
-use clap::Subcommand;
 use clap::Args;
+use clap::Subcommand;
+use console::style;
+use indicatif::ProgressBar;
+use indicatif::ProgressStyle;
 use log::{debug, info};
 use semver::VersionReq;
 use std::io;
 use std::str::FromStr;
-use console::style;
+use std::time::Duration;
 use unity_version::Version;
+use uvm_live_platform::UnityReleaseDownloadArchitecture;
+use uvm_live_platform::UnityReleaseDownloadPlatform;
 use uvm_live_platform::{UnityReleaseEntitlement, UnityReleaseStream};
 
 #[derive(Args, Debug)]
@@ -27,31 +32,59 @@ enum Command {
         #[command(flatten)]
         filter: VersionFilter,
 
+        /// List all matching versions
+        #[arg(short, long)]
+        all: bool,
     },
     Latest {
         #[command(flatten)]
         filter: VersionFilter,
-    }
+    },
 }
 
 #[derive(Args, Debug)]
 struct VersionFilter {
-    #[arg(short, long="stream", value_enum)]
+    #[arg(short, long = "stream", value_enum)]
     streams: Vec<UnityReleaseStream>,
 
-    #[arg(short, long="entitlement", value_enum)]
+    #[arg(short, long = "entitlement", value_enum)]
     entitlements: Vec<UnityReleaseEntitlement>,
-}
 
+    #[arg(long = "architecture", value_enum)]
+    architectures: Vec<UnityReleaseDownloadArchitecture>,
+
+    #[arg(long = "platform", value_enum)]
+    platforms: Vec<UnityReleaseDownloadPlatform>,
+}
 
 impl VersionCommand {
     pub fn execute(self) -> io::Result<i32> {
         let command = self.command;
-        
+
+        let pb = ProgressBar::new_spinner();
+        pb.enable_steady_tick(Duration::from_millis(120));
+        pb.set_style(
+            ProgressStyle::with_template("{spinner:.blue} {msg}")
+                .unwrap()
+                // For more spinners check out the cli-spinners project:
+                // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
+                .tick_strings(&[
+                    "▹▹▹▹▹",
+                    "▸▹▹▹▹",
+                    "▹▸▹▹▹",
+                    "▹▹▸▹▹",
+                    "▹▹▹▸▹",
+                    "▹▹▹▹▸",
+                    "▪▪▪▪▪",
+                ]),
+        );
+        pb.set_message(format!("{}", style("fetching versions").yellow()));
+
         match command {
-            Command::Latest { filter} => {
+            Command::Latest { filter } => {
                 let versions_builder = uvm_live_platform::ListVersions::builder()
-                    .for_current_system()
+                    .with_architectures(filter.architectures)
+                    .with_platforms(filter.platforms)
                     .autopage(false)
                     .with_streams(filter.streams)
                     .with_entitlements(filter.entitlements)
@@ -65,12 +98,17 @@ impl VersionCommand {
                         format!("No version found matching for provided filter"),
                     )
                 })?;
-                info!("highest matching version:");
-                eprintln!("{}", style(version).green().bold()); 
-            },
-            Command::Matching { version_req, filter} => {
+                pb.finish_with_message("latest version");
+                println!("{}", style(version).green().bold());
+            }
+            Command::Matching {
+                version_req,
+                filter,
+                all,
+            } => {
                 let versions_builder = uvm_live_platform::ListVersions::builder()
-                    .for_current_system()
+                    .with_architectures(filter.architectures)
+                    .with_platforms(filter.platforms)
                     .autopage(true)
                     .with_streams(filter.streams)
                     .with_entitlements(filter.entitlements);
@@ -79,63 +117,67 @@ impl VersionCommand {
                     .list()
                     .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{}", err)))?;
 
-                let versions = versions.into_iter().filter_map(|v| Version::from_str(&v).ok());
+                let versions = versions
+                    .into_iter()
+                    .filter_map(|v| Version::from_str(&v).ok());
 
                 debug!("versions: {:#?}", versions);
 
-                let version = Self::fetch_matching_version(versions, version_req)?;
-                info!("highest matching version:");
-                eprintln!("{}", style(version).green().bold()); 
+                if all {
+                    let versions = Self::fetch_matching_versions(versions, version_req);
+                    pb.finish_with_message("all matching versions");
+                    info!("all matching versions:");
+                    for version in versions {
+                        println!("{}", style(version).green().bold());
+                    }
+                } else {
+                    let version = Self::fetch_matching_version(versions, version_req)?;
+                    pb.finish_with_message("highest matching version");
+                    println!("{}", style(version).green().bold());
+                }
             }
         }
 
         Ok(0)
     }
 
+    fn fetch_matching_versions<I: Iterator<Item = Version>>(
+        versions: I,
+        version_req: VersionReq,
+    ) -> impl Iterator<Item = Version> {
+        versions.filter(move |version| {
+            let b = version.base().clone();
+            debug!(
+                "use base semver version {} of {} for comparison",
+                b, version
+            );
+            let semver_version = b;
+
+            let is_match = &version_req.matches(&semver_version);
+            if *is_match {
+                info!("version {} is a match", version);
+                true
+            } else {
+                info!("version {} is not a match", version);
+                false
+            }
+        })
+    }
+
     fn fetch_matching_version<I: Iterator<Item = Version>>(
         versions: I,
         version_req: VersionReq,
     ) -> io::Result<Version> {
-        versions
-            .filter(|version| {
-                // let semver_version = if version.release_type() < release_type {
-                //     debug!(
-                //         "version {} release type is smaller than specified type {:#}",
-                //         version, release_type
-                //     );
-                //     let mut semver_version = version.base().clone();
-                //     semver_version.pre = semver::Prerelease::new(&format!(
-                //         "{}.{}",
-                //         version.release_type(),
-                //         version.revision()
-                //     ))
-                //     .unwrap();
-                //     semver_version
-                // } else {
-                    let b = version.base().clone();
-                    debug!(
-                        "use base semver version {} of {} for comparison",
-                        b, version
-                    );
-                    let semver_version = b;
-                // };
-
-                let is_match = version_req.matches(&semver_version);
-                if is_match {
-                    info!("version {} is a match", version);
-                } else {
-                    info!("version {} is not a match", version);
-                }
-
-                is_match
-            })
+        Self::fetch_matching_versions(versions, version_req.clone())
             .max()
             .ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::NotFound,
-                    format!("No version found matching reg: {}", version_req.to_string()),
+                    format!(
+                        "No version found matching reg: {}",
+                        &version_req.to_string()
+                    ),
                 )
             })
     }
 }
-


### PR DESCRIPTION
## Description

The version command was printing only a single version. Either the latest released version of Unity matching some filter criteria like platform, stream etc

Or the highest matching version based on a version filter + platform, stream filters etc.

I also wanted to be able to list all matched versions. So the `matching` subcommand now supports `--all` to list all matching versions. I also improved the default filtering since for macOS arm there are no released alpha / beta versions. By default I leave the platform and arch empty.