### PR TITLE
Add uvm_detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,6 +2792,7 @@ dependencies = [
  "tempfile",
  "unity-hub",
  "unity-version",
+ "uvm_detect",
  "uvm_install",
  "uvm_live_platform",
 ]
@@ -2834,6 +2835,14 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uvm_detect"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
+ "unity-version",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ members = [
   "uvm_install",
   "unity-version",
   "unity-hub",
-  "unity-types"]
+  "unity-types",
+  "uvm_detect"
+]
 [workspace.dependencies]
 reqwest = { version = "0.12.23", default-features = false, features = ["rustls-tls-native-roots", "http2", "charset", "blocking", "json"] }
 serde = { version = "1.0.218", features = ["derive"] }

--- a/uvm/Cargo.toml
+++ b/uvm/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = {  version = "4.5.38", features = ["derive", "string", "env", "cargo"] }
 unity-version = { version = "0.2.0", path="../unity-version", features = ["clap"]}
+uvm_detect = { version = "0.1.0", path = "../uvm_detect" }
 console = { workspace = true }
 indicatif = "0.18.0"
 flexi_logger = "0.31.2"

--- a/uvm/src/commands/detect.rs
+++ b/uvm/src/commands/detect.rs
@@ -1,12 +1,8 @@
 use clap::Args;
 use log::info;
-use std::path::{Path, PathBuf};
-use std::{env, fs, io};
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::str::FromStr;
-use unity_version::Version;
+use uvm_detect::DetectOptions;
+use std::path::PathBuf;
+use std::{env, io};
 
 #[derive(Args, Debug)]
 pub struct DetectCommand {
@@ -24,142 +20,8 @@ impl DetectCommand {
         };
         
         info!("Detect the project version at path {}", project_path.display());
-        let version = self.detect_project_version(project_path, self.recursive)?;
+        let version = DetectOptions::new().recursive(self.recursive).detect_project_version(project_path)?; 
         println!("{}", version);
         Ok(0)
-    }
-
-    fn get_project_version<P: AsRef<Path>>(&self, base_dir: P) -> io::Result<PathBuf> {
-        let project_version = base_dir
-            .as_ref()
-            .join("ProjectSettings")
-            .join("ProjectVersion.txt");
-        if project_version.exists() {
-            Ok(project_version)
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "directory {} is not a Unity project",
-                    base_dir.as_ref().display()
-                ),
-            ))
-        }
-    }
-
-    pub fn detect_unity_project_dir(&self, dir: &Path, recur: bool) -> io::Result<PathBuf> {
-        let error = Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "Unable to find a Unity project",
-        ));
-
-        if dir.is_dir() {
-            if self.get_project_version(dir).is_ok() {
-                return Ok(dir.to_path_buf());
-            } else if !recur {
-                return error;
-            }
-
-            for entry in fs::read_dir(dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if path.is_dir() {
-                    let f = self.detect_unity_project_dir(&path, true);
-                    if f.is_ok() {
-                        return f;
-                    }
-                }
-            }
-        }
-        error
-    }
-
-    fn detect_project_version(&self, project_path: &Path, recur: bool) -> io::Result<Version> {
-        let project_version = self.detect_unity_project_dir(project_path, recur)
-            .and_then(|p| self.get_project_version(p))?;
-
-        let file = File::open(project_version)?;
-        let lines = BufReader::new(file).lines();
-
-        let mut editor_versions: HashMap<&'static str, String> = HashMap::with_capacity(2);
-
-        for line in lines {
-            if let Ok(line) = line {
-                if line.starts_with("m_EditorVersion: ") {
-                    let value = line.replace("m_EditorVersion: ", "");
-                    editor_versions.insert("EditorVersion", value.to_owned());
-                }
-
-                if line.starts_with("m_EditorVersionWithRevision: ") {
-                    let value = line.replace("m_EditorVersionWithRevision: ", "");
-                    editor_versions.insert("EditorVersionWithRevision", value.to_owned());
-                }
-            }
-        }
-
-        let v = editor_versions
-            .get("EditorVersionWithRevision")
-            .or_else(|| editor_versions.get("EditorVersion"))
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "Can't parse Unity version")
-            })?;
-        Version::from_str(&v)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "Can't parse Unity version"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[test]
-    fn detects_project_version_file() {
-        let temp = tempdir().unwrap();
-        let project_settings = temp.path().join("ProjectSettings");
-        fs::create_dir(&project_settings).unwrap();
-        let version_file = project_settings.join("ProjectVersion.txt");
-
-        let version_content = "m_EditorVersion: 2021.3.2f1";
-        fs::write(&version_file, version_content).unwrap();
-
-        let cmd = DetectCommand {
-            project_path: Some(temp.path().to_path_buf()),
-            recursive: false,
-        };
-
-        let version = cmd.detect_project_version(temp.path(), false).unwrap();
-        assert_eq!(version.to_string(), "2021.3.2f1");
-    }
-
-    #[test]
-    fn detects_nested_project_when_recursive() {
-        let temp = tempdir().unwrap();
-        let nested = temp.path().join("nested/project");
-        let project_settings = nested.join("ProjectSettings");
-        fs::create_dir_all(&project_settings).unwrap();
-        let version_file = project_settings.join("ProjectVersion.txt");
-        fs::write(&version_file, "m_EditorVersion: 2020.1.5f1").unwrap();
-
-        let cmd = DetectCommand {
-            project_path: Some(temp.path().to_path_buf()),
-            recursive: true,
-        };
-
-        let version = cmd.detect_project_version(temp.path(), true).unwrap();
-        assert_eq!(version.to_string(), "2020.1.5f1");
-    }
-
-    #[test]
-    fn fails_on_missing_project_version() {
-        let temp = tempdir().unwrap();
-
-        let cmd = DetectCommand {
-            project_path: Some(temp.path().to_path_buf()),
-            recursive: false,
-        };
-
-        let result = cmd.detect_project_version(temp.path(), false);
-        assert!(result.is_err());
     }
 }

--- a/uvm/src/commands/launch.rs
+++ b/uvm/src/commands/launch.rs
@@ -1,18 +1,14 @@
 use clap::{Args, ValueEnum};
+use console::style;
 use log::info;
 use std::env;
+use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::fs;
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::str::FromStr;
-use std::fmt;
-use console::style;
 use unity_hub::unity::{find_installation, list_all_installations, UnityInstallation};
-use unity_version::Version;
+use uvm_detect::detect_project_version;
+use uvm_detect::DetectOptions;
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum UnityPlatform {
@@ -77,11 +73,14 @@ pub struct LaunchCommand {
 
 impl LaunchCommand {
     pub fn execute(&self) -> io::Result<i32> {
-        let project_path = self.project_path
+        let project_path = self
+            .project_path
             .as_ref()
             .map(|p| p.to_path_buf())
             .unwrap_or_else(|| env::current_dir().expect("current working directory"));
-        let project_path = self.detect_unity_project_dir(&project_path, self.recursive)?;
+        let project_path = DetectOptions::new()
+            .recursive(self.recursive)
+            .detect_unity_project_dir(&project_path)?;
 
         info!("launch project: {}", style(&project_path.display()).cyan());
 
@@ -119,101 +118,31 @@ impl LaunchCommand {
         use_project_version: bool,
     ) -> io::Result<UnityInstallation> {
         if use_project_version {
-            let version = self.detect_project_version(project_path)?;
-            let installation = find_installation(&version)
-                .map_err(|e| io::Error::new(io::ErrorKind::NotFound, format!("Failed to find installation for version {}: {}", version, e)))?;
+            let version = detect_project_version(project_path)?;
+            let installation = find_installation(&version).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Failed to find installation for version {}: {}", version, e),
+                )
+            })?;
             return Ok(installation);
         }
 
         // For current installation, we'll use the first available installation
         // This is a simplified approach - in a real implementation you might want to
         // check for a specific "current" installation marker
-        let installations = list_all_installations()
-            .map_err(|e| io::Error::new(io::ErrorKind::NotFound, format!("Failed to list installations: {}", e)))?;
-        
-        let mut installations = installations;
-        let installation = installations
-            .next()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No Unity installations found"))?;
-        
-        Ok(installation)
-    }
-
-    fn detect_unity_project_dir(&self, dir: &Path, recur: bool) -> io::Result<PathBuf> {
-        let error = Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "Unable to find a Unity project",
-        ));
-
-        if dir.is_dir() {
-            if self.get_project_version(dir).is_ok() {
-                return Ok(dir.to_path_buf());
-            } else if !recur {
-                return error;
-            }
-
-            for entry in fs::read_dir(dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if path.is_dir() {
-                    let f = self.detect_unity_project_dir(&path, true);
-                    if f.is_ok() {
-                        return f;
-                    }
-                }
-            }
-        }
-        error
-    }
-
-    fn get_project_version<P: AsRef<Path>>(&self, base_dir: P) -> io::Result<PathBuf> {
-        let project_version = base_dir
-            .as_ref()
-            .join("ProjectSettings")
-            .join("ProjectVersion.txt");
-        if project_version.exists() {
-            Ok(project_version)
-        } else {
-            Err(io::Error::new(
+        let installations = list_all_installations().map_err(|e| {
+            io::Error::new(
                 io::ErrorKind::NotFound,
-                format!(
-                    "directory {} is not a Unity project",
-                    base_dir.as_ref().display()
-                ),
-            ))
-        }
-    }
+                format!("Failed to list installations: {}", e),
+            )
+        })?;
 
-    fn detect_project_version(&self, project_path: &Path) -> io::Result<Version> {
-        let project_version = self.detect_unity_project_dir(project_path, false)
-            .and_then(|p| self.get_project_version(p))?;
+        let mut installations = installations;
+        let installation = installations.next().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, "No Unity installations found")
+        })?;
 
-        let file = File::open(project_version)?;
-        let lines = BufReader::new(file).lines();
-
-        let mut editor_versions: HashMap<&'static str, String> = HashMap::with_capacity(2);
-
-        for line in lines {
-            if let Ok(line) = line {
-                if line.starts_with("m_EditorVersion: ") {
-                    let value = line.replace("m_EditorVersion: ", "");
-                    editor_versions.insert("EditorVersion", value.to_owned());
-                }
-
-                if line.starts_with("m_EditorVersionWithRevision: ") {
-                    let value = line.replace("m_EditorVersionWithRevision: ", "");
-                    editor_versions.insert("EditorVersionWithRevision", value.to_owned());
-                }
-            }
-        }
-
-        let v = editor_versions
-            .get("EditorVersionWithRevision")
-            .or_else(|| editor_versions.get("EditorVersion"))
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "Can't parse Unity version")
-            })?;
-        Version::from_str(&v)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "Can't parse Unity version"))
+        Ok(installation)
     }
 }

--- a/uvm_detect/Cargo.toml
+++ b/uvm_detect/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "uvm_detect"
+version = "0.1.0"
+edition = "2024"
+description = "Unity project detection and version extraction library"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/larusso/unity-version-manager"
+keywords = ["unity", "gamedev", "project-detection", "version"]
+categories = ["game-development", "filesystem"]
+
+[dependencies]
+unity-version = { version = "0.2.0", path = "../unity-version" }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/uvm_detect/README.md
+++ b/uvm_detect/README.md
@@ -1,0 +1,315 @@
+# uvm_detect
+
+A Rust library for detecting Unity projects and extracting Unity version information from project directories.
+
+## Overview
+
+`uvm_detect` provides utilities to:
+- 🔍 **Detect Unity projects** by searching for Unity project structure markers
+- 📋 **Extract Unity version information** from ProjectVersion.txt files
+- 🔄 **Support configurable recursive searching** with depth control
+- ✅ **Builder pattern API** similar to `std::fs::OpenOptions` for clean configuration
+- 🎯 **Follow Rust conventions** with proper error handling and idiomatic patterns
+
+## Features
+
+- **Builder Pattern API**: Clean, chainable configuration similar to `std::fs::OpenOptions`
+- **Project Detection**: Automatically locate Unity projects in directories
+- **Version Parsing**: Extract Unity editor versions from project files
+- **Flexible Search**: Support both current-directory and recursive searching
+- **Depth Control**: Configure maximum search depth to prevent excessive traversal
+- **Robust Error Handling**: Distinguish between different failure modes
+- **Cross-Platform**: Works consistently on Windows, macOS, and Linux
+- **Minimal Dependencies**: Only `unity-version` for version parsing
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+uvm_detect = "0.1.0"
+```
+
+## Usage
+
+### Basic Project Detection
+
+```rust
+use std::path::Path;
+use uvm_detect::DetectOptions;
+
+// Search for Unity project in current directory only
+match DetectOptions::new().detect_unity_project_dir(Path::new(".")) {
+    Ok(project_path) => {
+        println!("Found Unity project at: {}", project_path.display());
+    }
+    Err(_) => {
+        println!("No Unity project found in current directory");
+    }
+}
+```
+
+### Recursive Project Search
+
+```rust
+use std::path::Path;
+use uvm_detect::DetectOptions;
+
+// Search recursively through subdirectories
+match DetectOptions::new()
+    .recursive(true)
+    .detect_unity_project_dir(Path::new("./projects")) {
+    Ok(project_path) => {
+        println!("Found Unity project at: {}", project_path.display());
+    }
+    Err(_) => {
+        println!("No Unity project found in projects directory or subdirectories");
+    }
+}
+```
+
+### Recursive Search with Depth Limit
+
+```rust
+use std::path::Path;
+use uvm_detect::DetectOptions;
+
+// Search recursively but only 3 levels deep
+match DetectOptions::new()
+    .recursive(true)
+    .max_depth(3)
+    .detect_unity_project_dir(Path::new("./projects")) {
+    Ok(project_path) => {
+        println!("Found Unity project at: {}", project_path.display());
+    }
+    Err(_) => {
+        println!("No Unity project found within 3 directory levels");
+    }
+}
+```
+
+### Extract Unity Version
+
+```rust
+use std::path::Path;
+use uvm_detect::DetectOptions;
+
+// Get Unity version from a project directory
+match DetectOptions::new()
+    .recursive(true)
+    .max_depth(5)
+    .detect_project_version(Path::new("./my-unity-project")) {
+    Ok(version) => {
+        println!("Unity version: {}", version);
+    }
+    Err(e) => {
+        println!("Failed to detect Unity version: {}", e);
+    }
+}
+```
+
+### Convenience Functions
+
+For simple use cases, convenience functions are available:
+
+```rust
+use std::path::Path;
+use uvm_detect::{detect_unity_project_dir, detect_project_version, try_get_project_version};
+
+// Simple project detection (non-recursive)
+if let Ok(project_path) = detect_unity_project_dir(Path::new(".")) {
+    println!("Found Unity project at: {}", project_path.display());
+}
+
+// Simple version detection (non-recursive)
+if let Ok(version) = detect_project_version(Path::new("./my-unity-project")) {
+    println!("Unity version: {}", version);
+}
+
+// Check if a directory contains Unity project structure
+if let Some(version_file_path) = try_get_project_version(Path::new("./suspected-unity-project")) {
+    println!("Found Unity project! ProjectVersion.txt at: {}", version_file_path.display());
+} else {
+    println!("Not a Unity project directory");
+}
+```
+
+## Unity Project Structure
+
+This library detects Unity projects by looking for the standard Unity project structure:
+
+```
+UnityProject/
+├── ProjectSettings/
+│   └── ProjectVersion.txt    ← This file is the detection marker
+├── Assets/
+├── Library/
+└── ...
+```
+
+The `ProjectVersion.txt` file contains Unity editor version information in formats like:
+
+```
+m_EditorVersion: 2021.3.16f1
+m_EditorVersionWithRevision: 2021.3.16f1 (4016570cf34f)
+```
+
+## API Reference
+
+### DetectOptions
+
+The main configuration struct that provides a builder-style API for configuring Unity project detection.
+
+#### Methods
+
+##### `DetectOptions::new() -> Self`
+
+Creates a new `DetectOptions` with default settings:
+- `recursive`: false (search only in specified directory)
+- `max_depth`: u32::MAX (unlimited depth when recursive)
+- `case_sensitive`: true (for future use)
+
+##### `recursive(&mut self, recursive: bool) -> &mut Self`
+
+Sets whether to search recursively through subdirectories.
+
+##### `max_depth(&mut self, max_depth: u32) -> &mut Self`
+
+Sets the maximum depth to search when recursive search is enabled. Use `u32::MAX` for unlimited depth.
+
+##### `case_sensitive(&mut self, case_sensitive: bool) -> &mut Self`
+
+Sets whether to use case-sensitive path matching (reserved for future functionality).
+
+##### `detect_unity_project_dir(&self, dir: &Path) -> io::Result<PathBuf>`
+
+Detects a Unity project directory using the configured options.
+
+##### `detect_project_version(&self, dir: &Path) -> io::Result<Version>`
+
+Detects and parses the Unity version from a Unity project using the configured options.
+
+### Convenience Functions
+
+#### `detect_unity_project_dir(dir: &Path) -> io::Result<PathBuf>`
+
+Detects a Unity project directory using default options (non-recursive search).
+
+#### `detect_project_version(project_path: &Path) -> io::Result<Version>`
+
+Detects and parses the Unity version from a Unity project using default options.
+
+#### `try_get_project_version<P: AsRef<Path>>(base_dir: P) -> Option<PathBuf>`
+
+Attempts to get the path to the Unity ProjectVersion.txt file if it exists.
+
+## Configuration Examples
+
+### Complex Configuration
+
+```rust
+use std::path::Path;
+use uvm_detect::DetectOptions;
+
+let result = DetectOptions::new()
+    .recursive(true)                // Enable recursive search
+    .max_depth(10)                  // Limit to 10 directory levels
+    .case_sensitive(true)           // Use case-sensitive matching (future)
+    .detect_unity_project_dir(Path::new("./workspace"));
+
+match result {
+    Ok(project_path) => {
+        println!("Found Unity project at: {}", project_path.display());
+        
+        // Now get the version from the found project
+        let version = DetectOptions::new()
+            .detect_project_version(&project_path)?;
+        println!("Unity version: {}", version);
+    }
+    Err(e) => println!("No Unity project found: {}", e),
+}
+```
+
+### Performance Considerations
+
+```rust
+// For large directory trees, limit depth to improve performance
+let result = DetectOptions::new()
+    .recursive(true)
+    .max_depth(5)  // Only search 5 levels deep
+    .detect_unity_project_dir(Path::new("./large-workspace"));
+```
+
+## Error Handling
+
+The library uses Rust's standard error handling patterns:
+
+- **`io::Result<T>`** for operations that can fail due to I/O errors or missing projects
+- **`Option<T>`** for simple existence checks where absence isn't an error
+- **Specific error messages** that help identify the type of failure
+
+Common error scenarios:
+- **NotFound**: No Unity project found in the specified directory (or within max_depth if recursive)
+- **InvalidInput**: ProjectVersion.txt found but contains invalid version information
+- **I/O errors**: Permission denied, file not accessible, etc.
+
+## Testing
+
+Run the test suite:
+
+```bash
+cargo test
+```
+
+The library includes comprehensive tests covering:
+- ✅ Valid Unity project detection
+- ❌ Non-Unity directory handling
+- 🔄 Recursive search functionality
+- 📏 Max depth limiting
+- 📋 Version parsing with different formats
+- 🚫 Malformed version handling
+- 📁 Nested project structures
+- 🛠️ Builder pattern chaining
+- 🎯 Convenience functions
+
+## Performance
+
+- **Efficient traversal**: Stops at first Unity project found
+- **Depth limiting**: Prevents excessive directory traversal
+- **Early termination**: Returns immediately when project is found
+- **Minimal allocations**: Uses efficient path handling
+
+## Dependencies
+
+- `unity-version` - For parsing Unity version strings
+- `tempfile` (dev-dependency) - For creating temporary test directories
+
+## License
+
+This project is part of the Unity Version Manager (UVM) toolkit.
+
+## Contributing
+
+Contributions are welcome! Please ensure that:
+- All tests pass (`cargo test`)
+- Documentation tests compile (`cargo test --doc`)
+- Code follows Rust conventions
+- New features include appropriate tests
+- Documentation is updated for API changes
+
+## Related Projects
+
+This crate is part of the larger Unity Version Manager ecosystem:
+- `unity-version` - Unity version parsing and manipulation
+- `uvm_install` - Unity installation management  
+- `uvm` - Main CLI application
+
+## Changelog
+
+### v0.1.0
+- Initial release with builder pattern API
+- Support for recursive search with depth limiting
+- Cross-platform compatibility
+- Comprehensive test coverage
+- Clean separation of concerns between detection and version parsing

--- a/uvm_detect/src/lib.rs
+++ b/uvm_detect/src/lib.rs
@@ -1,0 +1,738 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{self, BufRead, BufReader},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use unity_version::Version;
+
+
+/// Configuration options for Unity project detection.
+///
+/// This struct provides a builder-style API similar to `std::fs::OpenOptions` for configuring
+/// how Unity project detection should behave. Use the builder methods to customize the search
+/// behavior, then call the detection methods to perform the actual search.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use uvm_detect::DetectOptions;
+///
+/// // Basic usage with default options
+/// let project_path = DetectOptions::new()
+///     .detect_unity_project_dir(Path::new("."))?;
+///
+/// // Recursive search with custom depth limit
+/// let project_path = DetectOptions::new()
+///     .recursive(true)
+///     .max_depth(3)
+///     .detect_unity_project_dir(Path::new("./projects"))?;
+///
+/// // Get version with custom options
+/// let version = DetectOptions::new()
+///     .recursive(true)
+///     .max_depth(5)
+///     .detect_project_version(Path::new("."))?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+#[derive(Default)]
+pub struct DetectOptions {
+    /// Whether to search recursively through subdirectories
+    pub recursive: bool,
+    /// Maximum depth to search when recursive is enabled (u32::MAX = unlimited)
+    pub max_depth: u32,
+    /// Whether to use case-sensitive path matching
+    pub case_sensitive: bool,
+}
+
+impl DetectOptions {
+    /// Creates a new `DetectOptions` with default settings.
+    ///
+    /// Default settings:
+    /// - `recursive`: false (search only in specified directory)
+    /// - `max_depth`: u32::MAX (unlimited depth when recursive)
+    /// - `case_sensitive`: true (use case-sensitive path matching)
+    pub fn new() -> Self {
+        Self {
+            recursive: false,
+            max_depth: u32::MAX,
+            case_sensitive: true,
+        }
+    }
+
+    /// Sets whether to search recursively through subdirectories.
+    ///
+    /// When `true`, the search will traverse into subdirectories looking for Unity projects.
+    /// When `false`, only the specified directory is searched.
+    ///
+    /// # Arguments
+    ///
+    /// * `recursive` - Whether to enable recursive search
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use uvm_detect::DetectOptions;
+    /// use std::path::Path;
+    ///
+    /// // Search recursively
+    /// let result = DetectOptions::new()
+    ///     .recursive(true)
+    ///     .detect_unity_project_dir(Path::new("."))?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn recursive(&mut self, recursive: bool) -> &mut Self {
+        self.recursive = recursive;
+        self
+    }
+
+    /// Sets the maximum depth to search when recursive search is enabled.
+    ///
+    /// This limits how deep the recursive search will go. A depth of 1 means only
+    /// immediate subdirectories are searched. Use `u32::MAX` for unlimited depth.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_depth` - Maximum search depth, or `u32::MAX` for unlimited
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use uvm_detect::DetectOptions;
+    /// use std::path::Path;
+    ///
+    /// // Search recursively but only 2 levels deep
+    /// let result = DetectOptions::new()
+    ///     .recursive(true)
+    ///     .max_depth(2)
+    ///     .detect_unity_project_dir(Path::new("."))?;
+    ///
+    /// // Search with unlimited depth
+    /// let result = DetectOptions::new()
+    ///     .recursive(true)
+    ///     .max_depth(u32::MAX)
+    ///     .detect_unity_project_dir(Path::new("."))?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn max_depth(&mut self, max_depth: u32) -> &mut Self {
+        self.max_depth = max_depth;
+        self
+    }
+
+
+    /// Sets whether to use case-sensitive path matching.
+    ///
+    /// This affects how file and directory names are compared during search.
+    ///
+    /// # Arguments
+    ///
+    /// * `case_sensitive` - Whether to use case-sensitive matching
+    ///
+    /// # Note
+    ///
+    /// This option is reserved for future functionality and does not currently affect behavior.
+    pub fn case_sensitive(&mut self, case_sensitive: bool) -> &mut Self {
+        self.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// Detects and parses the Unity version from a Unity project.
+    ///
+    /// This function locates a Unity project directory using the configured options and reads 
+    /// the ProjectVersion.txt file to extract Unity editor version information. It prioritizes 
+    /// the version with revision information if available, falling back to the basic editor version.
+    ///
+    /// # Arguments
+    ///
+    /// * `dir` - The directory path to start searching from
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Version)` - The parsed Unity version if found and valid
+    /// * `Err(io::Error)` - An error if the project is not found, the version file cannot be read,
+    ///   or the version string cannot be parsed
+    ///
+    /// # File Format
+    ///
+    /// The function reads ProjectSettings/ProjectVersion.txt and looks for lines like:
+    /// - `m_EditorVersion: 2021.3.16f1`
+    /// - `m_EditorVersionWithRevision: 2021.3.16f1 (4016570cf34f)`
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use uvm_detect::DetectOptions;
+    ///
+    /// // Basic version detection
+    /// let version = DetectOptions::new()
+    ///     .detect_project_version(Path::new("./my-unity-project"))?;
+    /// println!("Unity version: {}", version);
+    ///
+    /// // Recursive search with depth limit
+    /// let version = DetectOptions::new()
+    ///     .recursive(true)
+    ///     .max_depth(3)
+    ///     .detect_project_version(Path::new("./projects"))?;
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn detect_project_version(&self, dir: &Path) -> io::Result<Version> {
+        let project_version = self.detect_unity_project_dir(dir).and_then(|p| {
+            self.try_get_project_version(p).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "ProjectVersion.txt not found")
+            })
+        })?;
+
+        let file = File::open(project_version)?;
+        let lines = BufReader::new(file).lines();
+
+        let mut editor_versions: HashMap<&'static str, String> = HashMap::with_capacity(2);
+
+        for line in lines {
+            if let Ok(line) = line {
+                if line.starts_with("m_EditorVersion: ") {
+                    let value = line.replace("m_EditorVersion: ", "");
+                    editor_versions.insert("EditorVersion", value.to_owned());
+                }
+
+                if line.starts_with("m_EditorVersionWithRevision: ") {
+                    let value = line.replace("m_EditorVersionWithRevision: ", "");
+                    editor_versions.insert("EditorVersionWithRevision", value.to_owned());
+                }
+            }
+        }
+
+        let v = editor_versions
+            .get("EditorVersionWithRevision")
+            .or_else(|| editor_versions.get("EditorVersion"))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "Can't parse Unity version")
+            })?;
+        Version::from_str(&v)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "Can't parse Unity version"))
+    }
+
+    /// Detects a Unity project directory by searching for Unity project markers.
+    ///
+    /// This function searches for Unity project directories using the configured options. It looks 
+    /// for the presence of a valid Unity project structure (specifically, a ProjectSettings/ProjectVersion.txt file).
+    /// The search behavior (recursive vs. current directory only, max depth) is determined by the 
+    /// configuration set via the builder methods.
+    ///
+    /// # Arguments
+    ///
+    /// * `dir` - The directory path to start searching from
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(PathBuf)` - The path to the Unity project directory if found
+    /// * `Err(io::Error)` - An error if no Unity project is found or if there are I/O issues
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use uvm_detect::DetectOptions;
+    ///
+    /// // Search for Unity project in current directory only
+    /// if let Ok(project_path) = DetectOptions::new().detect_unity_project_dir(Path::new(".")) {
+    ///     println!("Found Unity project at: {}", project_path.display());
+    /// }
+    ///
+    /// // Search recursively through subdirectories with depth limit
+    /// match DetectOptions::new()
+    ///     .recursive(true)
+    ///     .max_depth(5)
+    ///     .detect_unity_project_dir(Path::new(".")) {
+    ///     Ok(project_path) => println!("Found Unity project at: {}", project_path.display()),
+    ///     Err(e) => println!("No Unity project found: {}", e),
+    /// }
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn detect_unity_project_dir(&self, dir: &Path) -> io::Result<PathBuf> {
+        self.detect_unity_project_dir_with_depth(dir, 0)
+    }
+
+    fn detect_unity_project_dir_with_depth(&self, dir: &Path, current_depth: u32) -> io::Result<PathBuf> {
+        let error = Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Unable to find a Unity project",
+        ));
+
+        // Check if the path is a directory
+        if !dir.is_dir() {
+            return error;
+        }
+
+        // Check if this directory contains a Unity project
+        if self.try_get_project_version(dir).is_some() {
+            return Ok(dir.to_path_buf());
+        }
+
+        // If not recursive, or we've hit max depth, stop here
+        if !self.recursive || current_depth >= self.max_depth {
+            return error;
+        }
+
+        // Search subdirectories
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            
+            // Only recurse into directories
+            if path.is_dir() {
+                let result = self.detect_unity_project_dir_with_depth(&path, current_depth + 1);
+                if result.is_ok() {
+                    return result;
+                }
+            }
+        }
+
+        error
+    }
+
+    /// Attempts to get the path to the Unity ProjectVersion.txt file if it exists.
+    ///
+    /// This function constructs the expected path to Unity's ProjectVersion.txt file
+    /// within a Unity project structure and checks if the file exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_dir` - The base directory to check for Unity project structure
+    ///
+    /// # Returns
+    ///
+    /// * `Some(PathBuf)` - The path to ProjectSettings/ProjectVersion.txt if it exists
+    /// * `None` - If the file doesn't exist (indicating the directory is not a Unity project)
+    ///
+    /// # Unity Project Structure
+    ///
+    /// A valid Unity project should have the following structure:
+    /// ```text
+    /// ProjectRoot/
+    /// ├── ProjectSettings/
+    /// │   └── ProjectVersion.txt  ← This file is checked
+    /// ├── Assets/
+    /// └── ...
+    /// ```
+    fn try_get_project_version<P: AsRef<Path>>(&self, base_dir: P) -> Option<PathBuf> {
+        let project_version = base_dir
+            .as_ref()
+            .join("ProjectSettings")
+            .join("ProjectVersion.txt");
+        if project_version.exists() {
+            Some(project_version)
+        } else {
+            None
+        }
+    }
+}
+
+/// Detects a Unity project directory using default options.
+///
+/// This is a convenience function that uses default detection options (non-recursive search).
+/// For more control over the search behavior, use `DetectOptions`.
+///
+/// # Arguments
+///
+/// * `dir` - The directory path to search in
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The path to the Unity project directory if found
+/// * `Err(io::Error)` - An error if no Unity project is found
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use uvm_detect::{detect_unity_project_dir, DetectOptions};
+///
+/// // Simple search in current directory
+/// let project_path = detect_unity_project_dir(Path::new("."))?;
+///
+/// // For recursive search, use DetectOptions
+/// let project_path = DetectOptions::new()
+///     .recursive(true)
+///     .detect_unity_project_dir(Path::new("."))?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn detect_unity_project_dir(dir: &Path) -> io::Result<PathBuf> {
+    DetectOptions::new().detect_unity_project_dir(dir)
+}
+
+/// Detects and parses the Unity version from a Unity project using default options.
+///
+/// This is a convenience function that uses default detection options (non-recursive search).
+/// For more control over the search behavior, use `DetectOptions`.
+///
+/// This function locates a Unity project directory and reads the ProjectVersion.txt file
+/// to extract the Unity editor version information. It prioritizes the version with
+/// revision information if available, falling back to the basic editor version.
+///
+/// # Arguments
+///
+/// * `project_path` - The path to start searching for a Unity project
+///
+/// # Returns
+///
+/// * `Ok(Version)` - The parsed Unity version if found and valid
+/// * `Err(io::Error)` - An error if the project is not found, the version file cannot be read,
+///   or the version string cannot be parsed
+///
+/// # File Format
+///
+/// The function reads ProjectSettings/ProjectVersion.txt and looks for lines like:
+/// - `m_EditorVersion: 2021.3.16f1`
+/// - `m_EditorVersionWithRevision: 2021.3.16f1 (4016570cf34f)`
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use uvm_detect::{detect_project_version, DetectOptions};
+///
+/// // Simple version detection
+/// let version = detect_project_version(Path::new("./my-unity-project"))?;
+/// println!("Unity version: {}", version);
+///
+/// // For recursive search with custom options
+/// let version = DetectOptions::new()
+///     .recursive(true)
+///     .max_depth(3)
+///     .detect_project_version(Path::new("./projects"))?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn detect_project_version(project_path: &Path) -> io::Result<Version> {
+    DetectOptions::new().detect_project_version(project_path)
+}
+
+/// Attempts to get the path to the Unity ProjectVersion.txt file if it exists.
+/// 
+/// Convenience function using default detection options.
+pub fn try_get_project_version<P: AsRef<Path>>(base_dir: P) -> Option<PathBuf> {
+    DetectOptions::new().try_get_project_version(base_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn create_unity_project(base_dir: &Path, version_content: &str) -> std::io::Result<()> {
+        let project_settings = base_dir.join("ProjectSettings");
+        fs::create_dir_all(&project_settings)?;
+
+        let version_file = project_settings.join("ProjectVersion.txt");
+        fs::write(version_file, version_content)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_try_get_project_version_valid_project() {
+        let temp_dir = TempDir::new().unwrap();
+        create_unity_project(temp_dir.path(), "m_EditorVersion: 2021.3.16f1").unwrap();
+
+        let result = try_get_project_version(temp_dir.path());
+        assert!(result.is_some());
+
+        let path = result.unwrap();
+        assert!(path.ends_with("ProjectSettings/ProjectVersion.txt"));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_try_get_project_version_no_project() {
+        let temp_dir = TempDir::new().unwrap();
+        // Don't create Unity project structure
+
+        let result = try_get_project_version(temp_dir.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_try_get_project_version_missing_project_settings() {
+        let temp_dir = TempDir::new().unwrap();
+        // Create directory but no ProjectSettings
+        fs::create_dir(temp_dir.path().join("Assets")).unwrap();
+
+        let result = try_get_project_version(temp_dir.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_unity_project_dir_current_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        create_unity_project(temp_dir.path(), "m_EditorVersion: 2021.3.16f1").unwrap();
+
+        let result = detect_unity_project_dir(temp_dir.path());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), temp_dir.path());
+    }
+
+    #[test]
+    fn test_detect_unity_project_dir_not_found_no_recursion() {
+        let temp_dir = TempDir::new().unwrap();
+        // Create a subdirectory with Unity project, but don't search recursively
+        let subdir = temp_dir.path().join("subproject");
+        fs::create_dir(&subdir).unwrap();
+        create_unity_project(&subdir, "m_EditorVersion: 2021.3.16f1").unwrap();
+
+        let result = detect_unity_project_dir(temp_dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_unity_project_dir_recursive_search() {
+        let temp_dir = TempDir::new().unwrap();
+        // Create a subdirectory with Unity project and search recursively
+        let subdir = temp_dir.path().join("subproject");
+        fs::create_dir(&subdir).unwrap();
+        create_unity_project(&subdir, "m_EditorVersion: 2021.3.16f1").unwrap();
+
+        let result = DetectOptions::new().recursive(true).detect_unity_project_dir(temp_dir.path());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), subdir);
+    }
+
+    #[test]
+    fn test_detect_unity_project_dir_nested_recursive() {
+        let temp_dir = TempDir::new().unwrap();
+        // Create nested directories with Unity project deep inside
+        let nested_path = temp_dir
+            .path()
+            .join("level1")
+            .join("level2")
+            .join("unity_project");
+        fs::create_dir_all(&nested_path).unwrap();
+        create_unity_project(&nested_path, "m_EditorVersion: 2021.3.16f1").unwrap();
+
+        let result = DetectOptions::new().recursive(true).detect_unity_project_dir(temp_dir.path());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), nested_path);
+    }
+
+    #[test]
+    fn test_detect_project_version_with_editor_version() {
+        let temp_dir = TempDir::new().unwrap();
+        let version_content =
+            "m_EditorVersion: 2021.3.16f1\nm_EditorVersionWithRevision: 2021.3.16f1 (4016570cf34f)";
+        create_unity_project(temp_dir.path(), version_content).unwrap();
+
+        let result = detect_project_version(temp_dir.path());
+        assert!(result.is_ok());
+
+        let version = result.unwrap();
+        assert_eq!(version.to_string(), "2021.3.16f1");
+    }
+
+    #[test]
+    fn test_detect_project_version_with_revision() {
+        let temp_dir = TempDir::new().unwrap();
+        let version_content =
+            "m_EditorVersion: 2020.3.1f1\nm_EditorVersionWithRevision: 2021.3.16f1 (4016570cf34f)";
+        create_unity_project(temp_dir.path(), version_content).unwrap();
+
+        let result = detect_project_version(temp_dir.path());
+        assert!(result.is_ok());
+
+        let version = result.unwrap();
+        // Should prefer the version with revision
+        assert_eq!(version.to_string(), "2021.3.16f1");
+    }
+
+    #[test]
+    fn test_detect_project_version_only_editor_version() {
+        let temp_dir = TempDir::new().unwrap();
+        let version_content = "m_EditorVersion: 2019.4.31f1\nSomeOtherField: value";
+        create_unity_project(temp_dir.path(), version_content).unwrap();
+
+        let result = detect_project_version(temp_dir.path());
+        assert!(result.is_ok());
+
+        let version = result.unwrap();
+        assert_eq!(version.to_string(), "2019.4.31f1");
+    }
+
+    #[test]
+    fn test_detect_project_version_no_version_info() {
+        let temp_dir = TempDir::new().unwrap();
+        let version_content = "SomeField: value\nAnotherField: another_value";
+        create_unity_project(temp_dir.path(), version_content).unwrap();
+
+        let result = detect_project_version(temp_dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_project_version_malformed_version() {
+        let temp_dir = TempDir::new().unwrap();
+        let version_content = "m_EditorVersion: not_a_valid_version";
+        create_unity_project(temp_dir.path(), version_content).unwrap();
+
+        let result = detect_project_version(temp_dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_project_version_recursive() {
+        let temp_dir = TempDir::new().unwrap();
+        let subdir = temp_dir.path().join("my_project");
+        fs::create_dir(&subdir).unwrap();
+        create_unity_project(&subdir, "m_EditorVersion: 2022.1.5f1").unwrap();
+
+        let result = DetectOptions::new().recursive(true).detect_project_version(temp_dir.path());
+        assert!(result.is_ok());
+
+        let version = result.unwrap();
+        assert_eq!(version.to_string(), "2022.1.5f1");
+    }
+
+    #[test]
+    fn test_detect_project_version_no_project_found() {
+        let temp_dir = TempDir::new().unwrap();
+        // Empty directory with no Unity project
+
+        let result = DetectOptions::new().recursive(true).detect_project_version(temp_dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_options_builder_pattern() {
+        let temp_dir = TempDir::new().unwrap();
+        let subdir = temp_dir.path().join("nested").join("project");
+        fs::create_dir_all(&subdir).unwrap();
+        create_unity_project(&subdir, "m_EditorVersion: 2023.1.0f1").unwrap();
+
+        // Test builder pattern chaining
+        let result = DetectOptions::new()
+            .recursive(true)
+            .max_depth(5)
+            .case_sensitive(true)
+            .detect_unity_project_dir(temp_dir.path());
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), subdir);
+    }
+
+    #[test]
+    fn test_detect_options_convenience_functions() {
+        let temp_dir = TempDir::new().unwrap();
+        create_unity_project(temp_dir.path(), "m_EditorVersion: 2022.3.5f1").unwrap();
+
+        // Test convenience function
+        let result = detect_unity_project_dir(temp_dir.path());
+        assert!(result.is_ok());
+
+        // Test convenience function for version detection
+        let version_result = detect_project_version(temp_dir.path());
+        assert!(result.is_ok());
+        assert_eq!(version_result.unwrap().to_string(), "2022.3.5f1");
+    }
+
+    #[test] 
+    fn test_detect_options_default_vs_custom() {
+        let temp_dir = TempDir::new().unwrap();
+        let subdir = temp_dir.path().join("deep").join("project");
+        fs::create_dir_all(&subdir).unwrap();
+        create_unity_project(&subdir, "m_EditorVersion: 2021.2.8f1").unwrap();
+
+        // Default options should not find nested project
+        let default_result = DetectOptions::new().detect_unity_project_dir(temp_dir.path());
+        assert!(default_result.is_err());
+
+        // Custom options with recursion should find it
+        let recursive_result = DetectOptions::new()
+            .recursive(true)
+            .detect_unity_project_dir(temp_dir.path());
+        assert!(recursive_result.is_ok());
+        assert_eq!(recursive_result.unwrap(), subdir);
+    }
+
+    #[test]
+    fn test_max_depth_limiting() {
+        let temp_dir = TempDir::new().unwrap();
+        
+        // Create a deep nested structure: temp/level1/level2/level3/project
+        let deep_project = temp_dir.path()
+            .join("level1")
+            .join("level2") 
+            .join("level3")
+            .join("project");
+        fs::create_dir_all(&deep_project).unwrap();
+        create_unity_project(&deep_project, "m_EditorVersion: 2023.2.1f1").unwrap();
+
+        // With max_depth = 2, should not find the project (it's at depth 4)
+        let limited_result = DetectOptions::new()
+            .recursive(true)
+            .max_depth(2)
+            .detect_unity_project_dir(temp_dir.path());
+        assert!(limited_result.is_err());
+
+        // With max_depth = 5, should find the project
+        let deep_result = DetectOptions::new()
+            .recursive(true)
+            .max_depth(5)
+            .detect_unity_project_dir(temp_dir.path());
+        assert!(deep_result.is_ok());
+        assert_eq!(deep_result.unwrap(), deep_project);
+
+        // With no max_depth limit, should also find it
+        let unlimited_result = DetectOptions::new()
+            .recursive(true)
+            .detect_unity_project_dir(temp_dir.path());
+        assert!(unlimited_result.is_ok());
+        assert_eq!(unlimited_result.unwrap(), deep_project);
+    }
+
+    #[test]
+    fn test_max_depth_zero_means_current_only() {
+        let temp_dir = TempDir::new().unwrap();
+        
+        // Create Unity project in subdirectory
+        let subdir = temp_dir.path().join("subproject");
+        fs::create_dir(&subdir).unwrap();
+        create_unity_project(&subdir, "m_EditorVersion: 2022.1.0f1").unwrap();
+
+        // With max_depth = 0 and recursive = true, should behave like recursive = false
+        let depth_zero_result = DetectOptions::new()
+            .recursive(true)
+            .max_depth(0)
+            .detect_unity_project_dir(temp_dir.path());
+        assert!(depth_zero_result.is_err());
+
+        // But should still find project in the current directory
+        let current_dir_result = DetectOptions::new()
+            .recursive(true)
+            .max_depth(0)
+            .detect_unity_project_dir(&subdir);
+        assert!(current_dir_result.is_ok());
+        assert_eq!(current_dir_result.unwrap(), subdir);
+    }
+
+    #[test]
+    fn test_combined_options() {
+        let temp_dir = TempDir::new().unwrap();
+        
+        // Create a structure: temp/level1/level2/project
+        let project_path = temp_dir.path().join("level1").join("level2").join("project");
+        fs::create_dir_all(&project_path).unwrap();
+        create_unity_project(&project_path, "m_EditorVersion: 2023.1.15f1").unwrap();
+
+        // Test combining recursive, max_depth, and other options
+        let result = DetectOptions::new()
+            .recursive(true)
+            .max_depth(3)
+            .case_sensitive(true)
+            .detect_unity_project_dir(temp_dir.path());
+        
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), project_path);
+    }
+}


### PR DESCRIPTION
## Description

The latest refactorings added some code duplication inside the unity-version-manager crate. I also saw that I still used `uvm_core` in a downstream project to use this now private APIs.

To make these APIs available and to reduce code duplication I decided to move them into a new crate called `uvm_detect`