### PR TITLE
Improve unity version parsing and allow to parse CompleteVersion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,6 +2841,7 @@ dependencies = [
 name = "uvm_detect"
 version = "1.0.0"
 dependencies = [
+ "regex",
  "tempfile",
  "unity-version",
 ]

--- a/unity-version/src/lib.rs
+++ b/unity-version/src/lib.rs
@@ -3,6 +3,8 @@ pub mod error;
 mod sys;
 
 pub use version::Version;
+pub use version::RevisionHash;
+pub use version::CompleteVersion;
 pub use version::ReleaseType;
 
 

--- a/unity-version/src/version/mod.rs
+++ b/unity-version/src/version/mod.rs
@@ -2,14 +2,15 @@ use crate::sys::version as version_impl;
 use derive_more::Display;
 use nom::{
     branch::alt,
-    character::complete::{char, digit1},
-    combinator::map_res,
+    character::complete::{char, digit1, hex_digit1, space1},
+    combinator::{map_res, verify},
     error::context,
+    sequence::delimited,
     IResult, Parser,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::{Path, PathBuf};
-use std::{cmp::Ordering, str::FromStr};
+use std::{cmp::Ordering, str::FromStr, sync::OnceLock};
 use regex::Regex;
 
 mod release_type;
@@ -167,14 +168,18 @@ impl Version {
     }
 
     pub fn from_string_containing<S: AsRef<str>>(s: S) -> Result<Self, VersionError> {
+        static VERSION_REGEX: OnceLock<Regex> = OnceLock::new();
+        let regex = VERSION_REGEX.get_or_init(|| {
+            Regex::new(r"\b\d+\.\d+\.\d+[fabp]\d+\b").unwrap()
+        });
+        
         let s = s.as_ref();
-
-            let re = Regex::new(r"\b\d+\.\d+\.\d+[fabp]\d+\b").unwrap();
-            for mat in re.find_iter(s){
-                if let Ok(version) = Version::from_str(mat.as_str()) {
-                    return Ok(version);
-                }
+        
+        for mat in regex.find_iter(s) {
+            if let Ok(version) = Version::from_str(mat.as_str()) {
+                return Ok(version);
             }
+        }
             Err(VersionError::ParsingFailed(format!("Could not find a valid Unity version in string: {}", s)))
     }
 
@@ -189,6 +194,65 @@ impl Version {
 pub struct CompleteVersion {
     version: Version,
     revision: RevisionHash,
+}
+
+impl CompleteVersion {
+    /// Creates a new CompleteVersion from a Version and RevisionHash.
+    pub fn new(version: Version, revision: RevisionHash) -> Self {
+        Self { version, revision }
+    }
+    
+    /// Gets the version component.
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+    
+    /// Gets the revision hash component.
+    pub fn revision(&self) -> &RevisionHash {
+        &self.revision
+    }
+}
+
+impl FromStr for CompleteVersion {
+    type Err = VersionError;
+
+    /// Parses a complete Unity version string with revision hash.
+    /// 
+    /// # Format
+    /// 
+    /// Expects format: "VERSION (REVISION_HASH)"
+    /// Examples: "2021.3.55f1 (f87d5274e360)", "2022.1.5f1 (abc123def456)"
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if:
+    /// - No revision hash is present
+    /// - Version format is invalid  
+    /// - Revision hash format is invalid
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match parse_complete_version(s.trim()) {
+            Ok((remaining, complete_version)) => {
+                if remaining.is_empty() {
+                    Ok(complete_version)
+                } else {
+                    Err(VersionError::ParsingFailed(
+                        format!("Unexpected remaining input: '{}'", remaining)
+                    ))
+                }
+            }
+            Err(err) => {
+                let error_msg = match err {
+                    nom::Err::Error(e) | nom::Err::Failure(e) => {
+                        format!("Parse error at: '{}'", e.input)
+                    }
+                    nom::Err::Incomplete(_) => {
+                        "Incomplete input".to_string()
+                    }
+                };
+                Err(VersionError::ParsingFailed(error_msg))
+            }
+        }
+    }
 }
 
 impl PartialEq for CompleteVersion {
@@ -236,6 +300,29 @@ fn parse_version(input: &str) -> IResult<&str, Version> {
     .parse(input)
 }
 
+fn parse_revision_hash(input: &str) -> IResult<&str, RevisionHash> {
+    context(
+        "revision hash",
+        map_res(
+            verify(hex_digit1, |s: &str| s.len() == 12),
+            |hex_str: &str| RevisionHash::new(hex_str)
+        )
+    ).parse(input)
+}
+
+fn parse_complete_version(input: &str) -> IResult<&str, CompleteVersion> {
+    context(
+        "complete version",
+        (
+            parse_version,
+            space1,
+            delimited(char('('), parse_revision_hash, char(')')),
+        )
+    )
+    .map(|(version, _, revision)| CompleteVersion::new(version, revision))
+    .parse(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,6 +346,61 @@ mod tests {
 
         assert_eq!(version.release_type, ReleaseType::Final);
         assert_eq!(version.revision, 4, "parse correct revision component");
+    }
+
+    #[test]
+    fn test_complete_version_from_str() {
+        // Test successful parsing
+        let complete_version = CompleteVersion::from_str("2021.3.55f1 (f87d5274e360)").unwrap();
+        assert_eq!(complete_version.version().to_string(), "2021.3.55f1");
+        assert_eq!(complete_version.revision().as_str(), "f87d5274e360");
+        assert_eq!(complete_version.to_string(), "2021.3.55f1 (f87d5274e360)");
+
+        // Test different version formats
+        let alpha_version = CompleteVersion::from_str("2023.1.0a1 (123456789abc)").unwrap();
+        assert_eq!(alpha_version.version().to_string(), "2023.1.0a1");
+        assert_eq!(alpha_version.revision().as_str(), "123456789abc");
+
+        // Test error cases with specific error message validation
+        
+        // No revision hash
+        let no_hash_result = CompleteVersion::from_str("2021.3.55f1");
+        assert!(no_hash_result.is_err());
+        let error_msg = no_hash_result.unwrap_err().to_string();
+        assert!(error_msg.contains("Parse error"), "Expected parsing error for missing hash, got: {}", error_msg);
+        
+        // Invalid version format
+        let invalid_version_result = CompleteVersion::from_str("invalid (f87d5274e360)");
+        assert!(invalid_version_result.is_err());
+        let error_msg = invalid_version_result.unwrap_err().to_string();
+        assert!(error_msg.contains("Parse error"), "Expected parsing error for invalid version, got: {}", error_msg);
+        
+        // Invalid hash characters
+        let invalid_hash_result = CompleteVersion::from_str("2021.3.55f1 (invalid)");
+        assert!(invalid_hash_result.is_err());
+        let error_msg = invalid_hash_result.unwrap_err().to_string();
+        assert!(error_msg.contains("Invalid revision hash") || error_msg.contains("Parse error"), 
+                "Expected revision hash error, got: {}", error_msg);
+        
+        // Hash too short
+        let short_hash_result = CompleteVersion::from_str("2021.3.55f1 (f87d527)");
+        assert!(short_hash_result.is_err());
+        let error_msg = short_hash_result.unwrap_err().to_string();
+        assert!(error_msg.contains("Invalid revision hash") || error_msg.contains("Parse error"), 
+                "Expected revision hash error for short hash, got: {}", error_msg);
+        
+        // Hash too long
+        let long_hash_result = CompleteVersion::from_str("2021.3.55f1 (f87d5274e360ab)");
+        assert!(long_hash_result.is_err());
+        let error_msg = long_hash_result.unwrap_err().to_string();
+        assert!(error_msg.contains("Parse error"), "Expected parsing error for long hash, got: {}", error_msg);
+        
+        // Non-hex characters in hash
+        let non_hex_result = CompleteVersion::from_str("2021.3.55f1 (f87d5274e36z)");
+        assert!(non_hex_result.is_err());
+        let error_msg = non_hex_result.unwrap_err().to_string();
+        assert!(error_msg.contains("Invalid revision hash") || error_msg.contains("Parse error"), 
+                "Expected revision hash error for non-hex chars, got: {}", error_msg);
     }
 
     #[test]

--- a/unity-version/src/version/revision_hash.rs
+++ b/unity-version/src/version/revision_hash.rs
@@ -1,5 +1,5 @@
 use thiserror::Error;
-use derive_more::{Deref, Display};
+use derive_more::Deref;
 use std::str::FromStr;
 
 #[derive(Debug, Error)]
@@ -12,10 +12,15 @@ pub enum RevisionHashError {
     InvalidCharacter,
 }
 
-#[derive(Eq, Debug, Clone, Hash, Display, Deref)]
-#[display("{}", 0)]
+#[derive(Eq, Debug, Clone, Hash, Deref)]
 #[allow(dead_code)]
 pub struct RevisionHash(String);
+
+impl std::fmt::Display for RevisionHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[allow(dead_code)]
 impl RevisionHash {

--- a/uvm_detect/Cargo.toml
+++ b/uvm_detect/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["game-development", "filesystem"]
 
 [dependencies]
 unity-version = { version = "0.2.0", path = "../unity-version" }
-
+regex = "1.11.0"
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
## Description

This patch adds new API to unity-version crate to parse version with revision hash. It also exposes the `CompleteVersion` struct to create and handle versions with revision hash included.

This new API is directly used in uvm_detect to return the new structs as well.