### PR TITLE
Fix Unity Hub errors and List installations

### DIFF
--- a/unity-hub/src/error.rs
+++ b/unity-hub/src/error.rs
@@ -5,17 +5,20 @@ use unity_version::error::VersionError;
 pub use crate::unity::error::*;
 #[derive(Error, Debug)]
 pub enum UnityHubError {
-    #[error("Unity Version error")]
+    #[error("Unity Version error: {0}")]
     VersionReadError(#[from] VersionError),
-
-    #[error("IO error")]
-    IoError(#[from] io::Error),
 
     #[error("api hub config: '{0}' is missing")]
     ConfigNotFound(String),
 
     #[error("Unity Hub config directory missing")]
     ConfigDirectoryNotFound,
+
+    #[error("Failed to locate application directory")]
+    ApplicationDirectoryNotFound {
+        #[source]
+        source: io::Error,
+    },
 
     #[error("failed to read Unity Hub config {config}")]
     ReadConfigError {
@@ -47,6 +50,13 @@ pub enum UnityHubError {
     FailedToListInstallations {
         path: PathBuf,
         source: io::Error
-    }
+    },
+
+    #[error("Installation with version {version} not found")]
+    InstallationNotFound {
+        version: String,
+        #[source]
+        source: io::Error,
+    },
 
 }

--- a/uvm_install/src/error.rs
+++ b/uvm_install/src/error.rs
@@ -7,13 +7,13 @@ pub type Result<T> = std::result::Result<T, InstallError>;
 
 #[derive(Error, Debug)]
 pub enum InstallError {
-    #[error("Failed to load Unity release")]
+    #[error("Failed to load Unity release: {0}")]
     ReleaseLoadFailure(#[from] LivePlatformError),
 
-    #[error("Unable to lock install process")]
+    #[error("Unable to lock install process: {0}")]
     LockProcessFailure(#[from] std::io::Error),
 
-    #[error("Unable to load installation")]
+    #[error("Unable to load installation: {0}")]
     UnityError(#[from] UnityError),
 
     #[error("Module '{0}' not supported for version '{1}'")]
@@ -28,7 +28,7 @@ pub enum InstallError {
     #[error("Installation failed for module {0}: {1}")]
     InstallFailed(String, #[source] install::error::InstallerError),
 
-    #[error("Some Hub error")]
+    #[error("Hub error: {0}")]
     HubError(#[from]unity_hub::error::UnityHubError),
 }
 

--- a/uvm_install/src/sys/mac/arch.rs
+++ b/uvm_install/src/sys/mac/arch.rs
@@ -15,7 +15,7 @@ enum ArchError {
     #[error("Unknown architecture")]
     UnknownArchitecture,
 
-    #[error("IO error")]
+    #[error("IO error: {0}")]
     IoError(#[from] io::Error),
 
     #[error("Mach file type not supported")]


### PR DESCRIPTION
## Description

The Unity Hub error type eats error context. So the error message will include now the error message from the source error.

Also the List Installation will error out when the requested directory doesn't exist. I seem to have un-commend the old test which was testing that this works.