### PR TITLE
Add Windows/Linux Arm64 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,6 +2857,7 @@ name = "uvm_install"
 version = "0.18.0"
 dependencies = [
  "cfg-if",
+ "clap",
  "cluFlock",
  "console",
  "dirs-2",

--- a/uvm/Cargo.toml
+++ b/uvm/Cargo.toml
@@ -25,7 +25,7 @@ log = { workspace = true }
 semver = { workspace = true }
 uvm_live_platform = { version = "0.6.0", path = "../uvm_live_platform", features = ["clap", "cache"] }
 unity-hub = { version = "0.5.1", path = "../unity-hub", features = ["mutate"] }
-uvm_install = { version = "0.18.0", path = "../uvm_install" }
+uvm_install = { version = "0.18.0", path = "../uvm_install", features = ["clap"]}
 itertools = { workspace = true }
 [dev-dependencies]
 tempfile = "3.19.1"

--- a/uvm_install/Cargo.toml
+++ b/uvm_install/Cargo.toml
@@ -9,10 +9,14 @@ categories = ["development-tools"]
 license = "Apache-2.0"
 edition = "2021"
 
+[features]
+clap = ["dep:clap"]
+
 [lib]
 name = "uvm_install"
 
 [dependencies]
+clap = { version = "4.5.38", features = ["derive"], optional = true }
 ssri = { workspace = true }
 uvm_move_dir = {path = "../uvm_move_dir", version = "0.2.2" }
 console = { workspace = true }

--- a/uvm_live_platform/src/model/platform.rs
+++ b/uvm_live_platform/src/model/platform.rs
@@ -12,12 +12,12 @@ pub enum UnityReleaseDownloadArchitecture {
 
 impl Default for UnityReleaseDownloadArchitecture {
     fn default() -> Self {
-        if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        if cfg!(target_arch = "x86_64") {
             Self::X86_64
-        } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        } else if cfg!(target_arch = "aarch64") {
             Self::Arm64
         } else {
-            Self::X86_64
+            panic!("Not supported on current architecture")
         }
     }
 }


### PR DESCRIPTION
## Description

With Unity 6 we can install the editor also on arm64 linux and windows distributions.

The arch types for the platform api and installation api where guarded to be arm64 supportive only on macOS.

I opened this up an also changed the way install gets called. Instead of a function I introduced a builder pattern fluent API.

I also cleaned out some pub use statements that got commited and release by accident.